### PR TITLE
feat(coordinacion): use shared layout navigation

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -90,10 +90,40 @@ export const routes: Routes = [
             .then(m => m.CoordinacionComponent),
       },
       {
+        path: 'notificaciones',
+        loadComponent: () =>
+          import('./features/coordinacion/Notificacion/notificacion.component')
+            .then(m => m.CoordinacionNotificacionComponent),
+      },
+      {
+        path: 'bandeja',
+        loadComponent: () =>
+          import('./features/coordinacion/Bandeja/bandeja.component')
+            .then(m => m.CoordinacionBandejaComponent),
+      },
+      {
+        path: 'estudiantes',
+        loadComponent: () =>
+          import('./features/coordinacion/estudiantes/estudiantes.component')
+            .then(m => m.CoordinacionEstudiantesComponent),
+      },
+      {
+        path: 'docentes',
+        loadComponent: () =>
+          import('./features/coordinacion/Docentes/docentes.component')
+            .then(m => m.CoordinacionDocentesComponent),
+      },
+      {
         path: 'practicas',
         loadComponent: () =>
           import('./features/coordinacion/practicas/practicas.component')
             .then(m => m.PracticasComponent),
+      },
+      {
+        path: 'perfil',
+        loadComponent: () =>
+          import('./features/coordinacion/Perfil/perfil.component')
+            .then(m => m.CoordinacionPerfilComponent),
       },
     ],
   },

--- a/frontend/src/app/features/coordinacion/Bandeja/bandeja.component.css
+++ b/frontend/src/app/features/coordinacion/Bandeja/bandeja.component.css
@@ -1,274 +1,170 @@
-/* =======================
-   DASHBOARD + SIDEBAR
-   ======================= */
-
-.dashboard {
-  display: flex;
-  min-height: 100vh;
+:host {
+  display: block;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f5f5f5;
 }
 
-/* Sidebar */
-.sidebar {
-  width: 110px; /* Reducido de 170px a 110px */
-  background: linear-gradient(180deg, #301e30 0%, #2a1a2a 100%);
-  color: white;
-  padding: 0;
+.bandeja-page {
   display: flex;
   flex-direction: column;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-  position: fixed; /* CAMBIADO: Ahora es fijo */
-  top: 0;
-  left: 0;
-  height: 100vh; /* Altura completa de la ventana */
-  z-index: 1000;
-  overflow: hidden;
+  gap: 1.5rem;
 }
 
-.sidebar.closed {
-  width: 65px; /* Ajustado proporcionalmente */
-}
-
-.logo-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0.5rem 1.5rem 0.2rem; /* Aumentado padding superior para dar espacio al toggle */
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  min-height: 100px; /* Aumentado ligeramente */
-  justify-content: center;
-  position: relative;
-}
-
-.logo-image {
-  width: 52px;
-  height: 65px;
-  object-fit: contain;
-  margin-bottom: 0.3rem;
-  transition: all 0.3s ease;
-}
-.sidebar.closed .logo-image {
-  width: 31px;
-  height: 41px;
-}
-
-.logo-title {
-  font-size: 0.6rem; /* Reducido de 0.7rem a 0.6rem */
-  font-weight: 600;
-  color: #008c6e;
+.ttl {
+  color: #1a3e6a;
   margin: 0;
-  text-align: center;
-  line-height: 1; /* Líneas más compactas */
-  transition: all 0.3s ease;
-  white-space: normal; /* Permitir que el texto se divida en líneas */
-  max-width: 90px; /* Aumentado el ancho máximo */
-  word-wrap: break-word; /* Dividir palabras largas si es necesario */
-  hyphens: auto; /* Guiones automáticos */
 }
 
-.logo-title.hidden {
-  opacity: 0;
-  transform: translateY(-10px);
+.wrap {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 16px;
+  min-height: 60vh;
 }
 
-/* Navegación optimizada - con scroll interno */
-.navigation {
-  flex: 1;
-  padding: 1rem 0;
-  overflow-y: auto; /* Permitir scroll interno si hay muchos elementos */
-  overflow-x: hidden;
-  opacity: 1;
-  transition: all 0.3s ease;
+.list {
+  background: #ffffff;
+  border: 1px solid var(--utem-border, #dfe5ee);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-/* Personalizar scrollbar del menú */
-.navigation::-webkit-scrollbar {
-  width: 4px;
+.search {
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+  padding: 8px 10px;
 }
 
-.navigation::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.navigation::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 2px;
-}
-
-.navigation::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.5);
-}
-
-/* Ocultar completamente la navegación cuando está cerrado */
-.sidebar.closed .navigation {
-  opacity: 0;
-  visibility: hidden;
-  height: 0;
-  padding: 0;
-}
-
-.navigation ul {
+.list ul {
   list-style: none;
-  padding: 0;
   margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  overflow: auto;
 }
-.nav-item {
-  margin: 0.01rem 1rem; /* Margen vertical*/
-  padding: 0.5rem; /* Tamaño Borde Opcion del menu*/
+
+.list li {
+  background: #f7faff;
+  border: 1px solid #e9eef6;
+  border-radius: 10px;
+  padding: 8px 10px;
   cursor: pointer;
-  display: flex;
-  flex-direction: column; /* CAMBIO: Columna en lugar de fila */
-  align-items: center;
-  gap: 0.4rem; /* Distancia Letras Icono */
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.list li:hover {
+  border-color: #bcd6ff;
+}
+
+.list li.active {
+  background: #e7f1ff;
+  border-color: #cfe3ff;
+}
+
+.btn.sm {
+  border: 0;
   border-radius: 8px;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  text-align: center; /* Centrar el texto */
-}
-
-/* Eliminar la regla específica para sidebar.closed .nav-item ya que estará oculto */
-
-.nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
-  transform: translateY(-2px); /* Cambio de dirección para que sea consistente con el layout vertical */
-}
-
-/* Estilo para el elemento activo en el menú */
-.nav-item.active {
-  background: rgba(255, 255, 255, 0.15);
-  border-left: 3px solid #00548c;
-}
-
-.nav-item.active .menu-icon {
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(0, 140, 74, 0.8));
-}
-
-.nav-item:active {
-  transform: translateY(-1px) scale(0.98);
-}
-
-.nav-item.logout {
-  margin-top: 0.4rem; /* Linea separadora Perfil - Cerrar Sesion */
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 0.4rem;
-}
-
-.nav-item.logout:hover {
-  background: rgba(220, 53, 69, 0.2);
-}
-
-/* Estilos específicos para los iconos del menú */
-.menu-icon {
-  width: 25px; /* Reducido de 22px a 18px */
-  height: 25px;
-  object-fit: contain;
-  transition: all 0.3s ease;
-  filter: brightness(0) invert(1);
-  margin-bottom: 0rem;
-}
-
-/* Ajustar tamaño cuando el menú está cerrado */
-.sidebar.closed .menu-icon {
-  width: 16px; /* Reducido de 20px a 16px */
-  height: 16px;
-  margin-bottom: 0;
-}
-
-/* Hover effect para los iconos */
-.nav-item:hover .menu-icon {
-  transform: scale(1.3);
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(255, 255, 255, 0.5));
-}
-
-/* Icono especial para logout */
-.nav-item.logout:hover .menu-icon {
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(220, 53, 69, 0.8));
-}
-
-/* Contenido */
-.content {
-  flex: 1;
-  padding: 2rem;
-  background: #f8f9fa;
-  margin-left: 110px;
-  transition: margin-left 0.3s ease;
-}
-.sidebar.closed + .content {
-  margin-left: 65px;
-}
-
-/* Botón toggle mejorado */
-.menu-toggle {
-  position: absolute;
-  top: 6.6rem;
-  right:0.1rem;
+  background: #1976d2;
+  color: #ffffff;
+  font-weight: 700;
+  padding: 6px 10px;
   cursor: pointer;
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 50%;
-  width: 30px;
-  height: 30px;
+  align-self: flex-start;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn.sm:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
+}
+
+.chat {
+  background: #ffffff;
+  border: 1px solid var(--utem-border, #dfe5ee);
+  border-radius: 12px;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
-  z-index: 10;
+  flex-direction: column;
+  min-height: 100%;
 }
 
-.menu-toggle:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: scale(1.1);
-}
-.content { flex:1; padding:2rem; background:#f8f9fa; margin-left:110px; transition:margin-left 0.3s ease; }
-.sidebar.closed + .content { margin-left:65px; }
-
-/* ======= BANDEJA DE ENTRADA (Código 2) ======= */
-.ttl { color:#1a3e6a; margin-bottom:8px; }
-.wrap { display:grid; grid-template-columns:320px 1fr; gap:16px; min-height:60vh; }
-.list { background:#fff; border:1px solid var(--utem-border,#dfe5ee); border-radius:12px; padding:12px; display:flex; flex-direction:column; gap:10px; }
-.search { border:1px solid #dfe5ee; border-radius:10px; padding:8px 10px; }
-.list ul { list-style:none; margin:0; padding:0; display:grid; gap:8px; overflow:auto; }
-.list li { background:#f7faff; border:1px solid #e9eef6; border-radius:10px; padding:8px 10px; cursor:pointer; }
-.list li.active { background:#e7f1ff; border-color:#cfe3ff; }
-.btn.sm { border:0; border-radius:8px; background:#1976D2; color:#fff; font-weight:800; padding:6px 10px; cursor:pointer; align-self:flex-start; }
-.chat { background:#fff; border:1px solid var(--utem-border,#dfe5ee); border-radius:12px; display:flex; flex-direction:column; }
-.chat header { display:flex; align-items:baseline; gap:8px; padding:12px 14px; border-bottom:1px solid var(--utem-border,#dfe5ee); }
-.msgs { flex:1; padding:12px 14px; display:grid; gap:8px; align-content:start; overflow-y:auto; }
-.bubble { max-width:60%; padding:10px 12px; border-radius:14px; background:#eef5ff; align-self:flex-start; }
-.bubble.me { background:#d1fae5; align-self:flex-end; }
-footer { display:flex; gap:10px; border-top:1px solid var(--utem-border,#dfe5ee); padding:10px; }
-.inp { flex:1; border:1px solid #dfe5ee; border-radius:10px; padding:8px 10px; }
-.send { border:0; border-radius:10px; background:#1976D2; color:#fff; padding:0 14px; font-weight:900; cursor:pointer; }
-
-.label {
-  font-size: 0.55rem; /* Reducido de 0.65rem a 0.55rem */
-  font-weight: 500;
-  transition: all 0.3s ease;
-  white-space: nowrap;
-  text-align: center;
-  line-height: 1;
-  max-width: 90px; /* Limitamos el ancho para evitar overflow */
-  overflow: hidden;
-  text-overflow: ellipsis;
+.chat header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--utem-border, #dfe5ee);
 }
 
-.label.hidden {
-  opacity: 0;
-  transform: translateY(-8px);
+.chat header h3 {
+  margin: 0;
+  color: #1a3e6a;
 }
 
-.info-label {
-  background: #f8f9fa;
-  font-weight: 600;
-  color: #555;
-  padding: 0.8rem 1rem;
-  border-bottom: 1px solid #e9ecef;
+.chat header small {
+  color: #6b7280;
 }
 
-.info-grid .info-row:last-child .info-label,
-.info-grid .info-row:last-child .info-value {
-  border-bottom: none;
+.msgs {
+  flex: 1;
+  padding: 12px 14px;
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  overflow-y: auto;
+}
+
+.bubble {
+  max-width: 60%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: #eef5ff;
+  align-self: flex-start;
+}
+
+.bubble.me {
+  background: #d1fae5;
+  align-self: flex-end;
+}
+
+footer {
+  display: flex;
+  gap: 10px;
+  border-top: 1px solid var(--utem-border, #dfe5ee);
+  padding: 10px;
+}
+
+.inp {
+  flex: 1;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+
+.send {
+  border: 0;
+  border-radius: 10px;
+  background: #1976d2;
+  color: #ffffff;
+  padding: 0 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.send:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
+}
+
+@media (max-width: 1024px) {
+  .wrap {
+    grid-template-columns: 1fr;
+  }
+
+  .chat {
+    min-height: auto;
+  }
 }

--- a/frontend/src/app/features/coordinacion/Bandeja/bandeja.component.html
+++ b/frontend/src/app/features/coordinacion/Bandeja/bandeja.component.html
@@ -1,93 +1,36 @@
-<div class="dashboard">
-  <!-- Sidebar del Código 1 -->
-  <aside class="sidebar" [ngClass]="{'open': menuOpen, 'closed': !menuOpen}">
-    <div class="logo-container" (click)="menuOpen ? null : toggleMenu()">
-      <img src="assets/utem.png" alt="Logo UTEM" class="logo-image" />
-      <h3 class="logo-title" [class.hidden]="!menuOpen">PROCESO DE TITULACIÓN</h3>
-    </div>
+<section class="bandeja-page">
+  <h2 class="ttl">Bandeja de Entrada</h2>
 
-    <div class="menu-toggle" (click)="toggleMenu()" [attr.aria-label]="menuOpen ? 'Cerrar menú' : 'Abrir menú'">
-      <span class="toggle-icon" [class.rotated]="!menuOpen">☰</span>
-    </div>
-
-    <nav class="navigation">
+  <div class="wrap">
+    <aside class="list">
+      <input class="search" placeholder="Buscar" />
       <ul>
-        <li class="nav-item" (click)="navigateTo('notificaciones')">
-          <img src="assets/Notificaciones.png" alt="Notificaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Notificaciones</span>
-        </li>
-        <li class="nav-item active" (click)="navigateTo('bandeja')">
-          <img src="assets/Bandeja_entrada.png" alt="Bandeja de entrada" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Bandeja de Entrada</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('inicio')">
-          <img src="assets/Inicio.png" alt="Inicio" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Inicio</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('estudiantes')">
-          <img src="assets/Estudiantes.png" alt="Estudiantes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Estudiantes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('docentes')">
-          <img src="assets/Docentes.png" alt="Docentes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Docentes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('procesos')">
-          <img src="assets/Procesos.png" alt="Procesos" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Procesos</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('evaluaciones')">
-          <img src="assets/Evaluaciones.png" alt="Evaluaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Evaluaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('reportes')">
-          <img src="assets/Reportes.png" alt="Reportes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Reportes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('perfil')">
-          <img src="assets/Perfil.png" alt="Perfil" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Perfil</span>
-        </li>
-        <li class="nav-item logout" (click)="logout()">
-          <img src="assets/Cerrar_Sesion.png" alt="Cerrar sesión" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Cerrar Sesión</span>
+        <li
+          *ngFor="let c of chats(); let i = index"
+          [class.active]="i === selected()"
+          (click)="selected.set(i)"
+        >
+          <b>{{ c.nombre }}</b>
+          <small>{{ c.asunto }}</small>
         </li>
       </ul>
-    </nav>
-  </aside>
+      <button class="btn sm" type="button">Nuevo mensaje</button>
+    </aside>
 
-  <!-- Contenido principal reemplazando perfil por Bandeja -->
-  <main class="content">
-    <h2 class="ttl">Bandeja de Entrada</h2>
-
-    <div class="wrap">
-      <!-- Sidebar de chats -->
-      <aside class="list">
-        <input class="search" placeholder="Buscar"/>
-        <ul>
-          <li *ngFor="let c of chats(); let i=index" 
-              [class.active]="i===selected()" 
-              (click)="selected.set(i)">
-            <b>{{c.nombre}}</b>
-            <small>{{c.asunto}}</small>
-          </li>
-        </ul>
-        <button class="btn sm">Nuevo mensaje</button>
-      </aside>
-
-      <!-- Chat seleccionado -->
-      <section class="chat">
-        <header>
-          <h3>{{chat.nombre}}</h3><small>{{chat.asunto}}</small>
-        </header>
-        <div class="msgs">
-          <div *ngFor="let m of chat.mensajes" [class.me]="m.yo" class="bubble">{{m.t}}</div>
+    <section class="chat" *ngIf="chat() as selectedChat">
+      <header>
+        <h3>{{ selectedChat.nombre }}</h3>
+        <small>{{ selectedChat.asunto }}</small>
+      </header>
+      <div class="msgs">
+        <div *ngFor="let m of selectedChat.mensajes" [class.me]="m.yo" class="bubble">
+          {{ m.t }}
         </div>
-        <footer>
-          <input class="inp" placeholder="Escribe un mensaje…"/>
-          <button class="send">➤</button>
-        </footer>
-      </section>
-    </div>
-  </main>
-</div>
+      </div>
+      <footer>
+        <input class="inp" placeholder="Escribe un mensaje…" />
+        <button class="send" type="button"></button>
+      </footer>
+    </section>
+  </div>
+</section>

--- a/frontend/src/app/features/coordinacion/Bandeja/bandeja.component.ts
+++ b/frontend/src/app/features/coordinacion/Bandeja/bandeja.component.ts
@@ -1,59 +1,42 @@
-import { Component, signal } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
-import { AuthService } from '../../../auth.service';
-
-interface UserProfile {
-  nombre: string;
-  correo: string;
-  carrera: string;
-  telefono?: string;
-  ultimoAcceso?: string;
-  contrasena?: string;
-}
 
 @Component({
   selector: 'app-bandeja',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule],
   templateUrl: './bandeja.component.html',
   styleUrls: ['./bandeja.component.css'],
 })
 export class CoordinacionBandejaComponent {
-  // Sidebar y menú
-  menuOpen = true;
-
-  // Bandeja de mensajes
-  selected = signal(0);
-  chats = signal([
-    { nombre:'Gabriel Ruiz', asunto:'Informe final', mensajes:[
-      { yo:false, t:'No olvides completar secciones.'},
-      { yo:true,  t:'Recibido, enviaré avances.'},
-    ]},
-    { nombre:'Natalia Rojas', asunto:'Revisión de avance', mensajes:[{ yo:false, t:'Revisa la metodología.' } ]},
+  readonly selected = signal(0);
+  readonly chats = signal([
+    {
+      nombre: 'Gabriel Ruiz',
+      asunto: 'Informe final',
+      mensajes: [
+        { yo: false, t: 'No olvides completar secciones.' },
+        { yo: true, t: 'Recibido, enviaré avances.' },
+      ],
+    },
+    {
+      nombre: 'Natalia Rojas',
+      asunto: 'Revisión de avance',
+      mensajes: [{ yo: false, t: 'Revisa la metodología.' }],
+    },
   ]);
-  get chat(){ return this.chats()[this.selected()]; }
 
-  constructor(private readonly authService: AuthService, private readonly router: Router) {}
-
-
-  toggleMenu(): void {
-    this.menuOpen = !this.menuOpen;
-  }
-
-  navigateTo(section: string): void {
-    console.log(`Navegando a: ${section}`);
-  }
-
-  logout(): void {
-    if (!confirm('¿Estás seguro de que quieres cerrar sesión?')) {
-      return;
+  readonly chat = computed(() => {
+    const conversations = this.chats();
+    if (!conversations.length) {
+      return undefined;
     }
 
-    this.authService.logout().subscribe({
-      next: () => this.router.navigateByUrl('/auth/login'),
-      error: () => this.router.navigateByUrl('/auth/login'),
-    });
-  }
+    const index = this.selected();
+    if (index < 0 || index >= conversations.length) {
+      return conversations[0];
+    }
+
+    return conversations[index];
+  });
 }

--- a/frontend/src/app/features/coordinacion/Docentes/docentes.component.css
+++ b/frontend/src/app/features/coordinacion/Docentes/docentes.component.css
@@ -1,724 +1,144 @@
-/* ===== Estadísticas Generales ===== */
-.stats-section {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 20px;
-  margin-bottom: 24px;
+:host {
+  display: block;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
-.stat-card {
-  background: white;
-  border-radius: 12px;
-  padding: 20px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e2e8f0;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.stat-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-
-.stat-icon {
-  font-size: 2.5rem;
-  width: 60px;
-  height: 60px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, #e0f2fe, #b3e5fc);
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.stat-info h3 {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #1e293b;
-  margin: 0;
-  line-height: 1;
-}
-
-.stat-info p {
-  font-size: 0.9rem;
-  color: #64748b;
-  margin: 4px 0 0 0;
-  font-weight: 500;
-}
-
-/* ===== Celdas específicas actualizadas ===== */
-.students-cell {
-  text-align: center;
-  min-width: 140px;
-}
-
-.students-count {
+.docentes-page {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 2px;
+  gap: 2rem;
 }
 
-.count-number {
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #1e293b;
-}
-
-.count-label {
-  font-size: 0.75rem;
-  color: #64748b;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.date-cell {
-  min-width: 120px;
-  text-align: center;
-}
-
-.date-info {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-}
-
-.date-text {
-  font-size: 0.875rem;
-  color: #374151;
-  font-weight: 500;
-}
-
-.date-badge {
-  padding: 2px 6px;
-  border-radius: 10px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.date-badge.warning {
-  background: #fef3c7;
-  color: #d97706;
-  border: 1px solid #fde68a;
-}
-
-.date-badge.overdue {
-  background: #fee2e2;
-  color: #dc2626;
-  border: 1px solid #fecaca;
-}
-
-.date-warning .date-text {
-  color: #d97706;
-  font-weight: 600;
-}
-
-.date-overdue .date-text {
-  color: #dc2626;
-  font-weight: 600;
-}
-
-/* ===== Barra de progreso ===== */
-.progress-cell {
-  min-width: 180px;
-  padding: 12px 20px;
-}
-
-.progress-container {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: center;
-}
-
-.progress-bar {
-  width: 100%;
-  height: 8px;
-  background: #f1f5f9;
-  border-radius: 10px;
-  overflow: hidden;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-}
-
-.progress-fill {
-  height: 100%;
-  border-radius: 10px;
-  transition: all 0.3s ease;
-  position: relative;
-}
-
-.progress-fill.completado {
-  background: linear-gradient(90deg, #10b981, #059669);
-}
-
-.progress-fill.progreso-alto {
-  background: linear-gradient(90deg, #3b82f6, #2563eb);
-}
-
-.progress-fill.progreso-medio {
-  background: linear-gradient(90deg, #f59e0b, #d97706);
-}
-
-.progress-fill.progreso-bajo {
-  background: linear-gradient(90deg, #ef4444, #dc2626);
-}
-
-.progress-fill.sin-progreso {
-  background: #e5e7eb;
-  width: 2px !important; /* Mostrar una pequeña línea */
-}
-
-.progress-text {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-}
-
-.completion-count {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #374151;
-}
-
-.completion-percentage {
-  font-size: 0.75rem;
-  color: #64748b;
-  font-weight: 500;
-}
-
-/* ===== Estilos para filas según completitud ===== */
-.table-row.high-completion {
-  background: rgba(16, 185, 129, 0.05);
-  border-left: 3px solid #10b981;
-}
-
-.table-row.low-completion {
-  background: rgba(239, 68, 68, 0.05);
-  border-left: 3px solid #ef4444;
-}
-
-.table-row.high-completion:hover {
-  background: rgba(16, 185, 129, 0.1);
-}
-
-.table-row.low-completion:hover {
-  background: rgba(239, 68, 68, 0.1);
-}
-
-/* ===== Botones de acción actualizados ===== */
-.action-buttons {
-  display: flex;
-  gap: 6px;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.action-btn {
-  min-width: 90px;
-  font-size: 0.75rem;
-  padding: 4px 8px;
-}
-
-/* ===== Responsivo mejorado ===== */
-@media (max-width: 1400px) {
-  .stats-section {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  
-  .action-buttons {
-    flex-direction: column;
-    gap: 4px;
-  }
-  
-  .action-btn {
-    min-width: 80px;
-    font-size: 0.7rem;
-  }
-}
-
-@media (max-width: 1024px) {
-  .progress-cell {
-    min-width: 150px;
-  }
-  
-  .progress-container {
-    gap: 4px;
-  }
-  
-  .completion-count {
-    font-size: 0.8rem;
-  }
-  
-  .completion-percentage {
-    font-size: 0.7rem;
-  }
-}
-
-@media (max-width: 768px) {
-  .stats-section {
-    grid-template-columns: 1fr;
-  }
-  
-  .stat-card {
-    padding: 16px;
-    gap: 12px;
-  }
-  
-  .stat-icon {
-    font-size: 2rem;
-    width: 50px;
-    height: 50px;
-  }
-  
-  .stat-info h3 {
-    font-size: 1.5rem;
-  }
-  
-  .data-table th,
-  .data-table td {
-    padding: 8px 12px;
-    font-size: 0.8rem;
-  }
-  
-  .students-cell,
-  .progress-cell,
-  .date-cell {
-    min-width: 100px;
-  }
-  
-  .progress-bar {
-    height: 6px;
-  }
-  
-  .docente-name {
-    font-size: 0.85rem;
-  }
-  
-  .docente-details {
-    font-size: 0.7rem;
-  }
-  
-  .action-btn {
-    padding: 3px 6px;
-    font-size: 0.65rem;
-    min-width: 70px;
-  }
-}
-
-/* ===== Animaciones mejoradas ===== */
-.progress-fill {
-  animation: progressLoad 0.8s ease-out;
-}
-
-@keyframes progressLoad {
-  from {
-    width: 0%;
-  }
-  to {
-    width: var(--final-width);
-  }
-}
-
-.stat-card {
-  animation: slideUp 0.4s ease-out;
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* ===== Mejoras adicionales en accesibilidad ===== */
-.progress-bar:focus-within {
-  outline: 2px solid #3b82f6;
-  outline-offset: 2px;
-}
-
-.date-badge {
-  user-select: none;
-}
-
-/* ===== Tooltips personalizados ===== */
-.progress-container[title]:hover::after {
-  content: attr(title);
-  position: absolute;
-  background: #1f2937;
-  color: white;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 0.75rem;
-  white-space: nowrap;
-  z-index: 1000;
-  margin-top: 5px;
-}
-
-/* ===== Estados de carga ===== */
-.loading .progress-fill {
-  background: linear-gradient(90deg, #e5e7eb, #d1d5db, #e5e7eb);
-  background-size: 200% 100%;
-  animation: loadingShimmer 2s infinite;
-}
-
-@keyframes loadingShimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-/* ===== Mejoras en contraste ===== */
-.table-row:nth-child(even) {
-  background: rgba(248, 250, 252, 0.7);
-}
-
-.table-row:nth-child(even):hover {
-  background: #f1f5f9;
-}
-
-/* ===== Indicadores visuales adicionales ===== */
-.progress-fill::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 3px;
-  height: 100%;
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 0 10px 10px 0;
-}
-
-.progress-fill.completado::after {
-  background: rgba(255, 255, 255, 0.4);
-}/* ESTILOS MEJORADOS PARA PANEL DE DOCENTES */
-
-/* ===== Estilos base del dashboard ===== */
-.dashboard {
-  display: flex;
-  min-height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  background-color: #f8fafc;
-  color: #334155;
-}
-
-/* ===== Sidebar (mantener estilos originales) ===== */
-.sidebar {
-  width: 110px;
-  background: linear-gradient(180deg, #301e30 0%, #2a1a2a 100%);
-  color: white;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100vh;
-  z-index: 1000;
-  overflow: hidden;
-}
-
-.sidebar.closed {
-  width: 65px;
-}
-
-.logo-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0.5rem 1.5rem 0.2rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  min-height: 100px;
-  justify-content: center;
-  position: relative;
-}
-
-.logo-image {
-  width: 52px;
-  height: 65px;
-  object-fit: contain;
-  margin-bottom: 0.3rem;
-  transition: all 0.3s ease;
-}
-
-.sidebar.closed .logo-image {
-  width: 31px;
-  height: 41px;
-}
-
-.logo-title {
-  font-size: 0.6rem;
-  font-weight: 600;
-  color: #008c6e;
-  margin: 0;
-  text-align: center;
-  line-height: 1;
-  transition: all 0.3s ease;
-  white-space: normal;
-  max-width: 90px;
-  word-wrap: break-word;
-  hyphens: auto;
-}
-
-.logo-title.hidden {
-  opacity: 0;
-  transform: translateY(-10px);
-}
-
-.menu-toggle {
-  position: absolute;
-  top: 6.6rem;
-  right: 0.1rem;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 50%;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
-  z-index: 10;
-}
-
-.menu-toggle:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: scale(1.1);
-}
-
-.toggle-icon {
-  font-size: 1.3rem;
-  transition: transform 0.3s ease;
-  color: white;
-}
-
-.navigation {
-  flex: 1;
-  padding: 1rem 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  opacity: 1;
-  transition: all 0.3s ease;
-}
-
-.navigation::-webkit-scrollbar {
-  width: 4px;
-}
-
-.navigation::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.navigation::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 2px;
-}
-
-.sidebar.closed .navigation {
-  opacity: 0;
-  visibility: hidden;
-  height: 0;
-  padding: 0;
-}
-
-.navigation ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.nav-item {
-  margin: 0.01rem 1rem;
-  padding: 0.5rem;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.4rem;
-  border-radius: 8px;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  text-align: center;
-}
-
-.nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
-  transform: translateY(-2px);
-}
-
-.nav-item.active {
-  background: rgba(255, 255, 255, 0.15);
-  border-left: 3px solid #00548c;
-}
-
-.nav-item.active .menu-icon {
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(0, 140, 74, 0.8));
-}
-
-.nav-item.logout {
-  margin-top: 0.4rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 0.4rem;
-}
-
-.nav-item.logout:hover {
-  background: rgba(220, 53, 69, 0.2);
-}
-
-.menu-icon {
-  width: 25px;
-  height: 25px;
-  object-fit: contain;
-  transition: all 0.3s ease;
-  filter: brightness(0) invert(1);
-  margin-bottom: 0rem;
-}
-
-.nav-item:hover .menu-icon {
-  transform: scale(1.3);
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(255, 255, 255, 0.5));
-}
-
-.label {
-  font-size: 0.55rem;
-  font-weight: 500;
-  transition: all 0.3s ease;
-  white-space: nowrap;
-  text-align: center;
-  line-height: 1;
-  max-width: 90px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.label.hidden {
-  opacity: 0;
-  transform: translateY(-8px);
-}
-
-/* ===== Contenido Principal ===== */
-.content {
-  flex: 1;
-  padding: 24px 32px;
-  overflow-y: auto;
-  transition: margin-left 0.3s ease;
-  background-color: #f8fafc;
-}
-
-/* ===== Header Mejorado ===== */
 .page-header {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  margin-bottom: 32px;
-  padding-bottom: 16px;
-  border-bottom: 2px solid #e2e8f0;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .title-section {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.5rem;
 }
 
 .title {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #1e293b;
   margin: 0;
-  letter-spacing: -0.025em;
+  color: #1a3e6a;
+  font-size: 2rem;
+  font-weight: 600;
 }
 
 .subtitle {
-  font-size: 0.95rem;
-  color: #64748b;
   margin: 0;
-  font-weight: 400;
+  color: #6c757d;
 }
 
 .header-actions {
   display: flex;
-  gap: 12px;
+  gap: 1rem;
   align-items: center;
 }
 
-/* ===== Filtros Mejorados ===== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, #6c757d, #5a6268);
+  color: #ffffff;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.15);
+}
+
+.btn-sm {
+  padding: 0.5rem 1rem;
+}
+
 .filters-section {
-  display: flex;
-  gap: 20px;
-  margin-bottom: 24px;
-  padding: 20px;
-  background: white;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  padding: 1.5rem;
+  background: #ffffff;
   border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e2e8f0;
-  align-items: flex-end;
-  flex-wrap: wrap;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  align-items: end;
 }
 
 .filter-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  min-width: 180px;
-}
-
-.filter-group label {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #374151;
-  margin: 0;
+  gap: 0.4rem;
 }
 
 .filter-select {
-  border: 2px solid #e2e8f0;
+  padding: 0.75rem;
   border-radius: 8px;
-  padding: 10px 14px;
-  background: #fff;
-  font-size: 0.9rem;
-  color: #374151;
-  transition: all 0.2s ease;
-  cursor: pointer;
+  border: 1px solid #dee2e6;
+  background: #ffffff;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .filter-select:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-}
-
-.filter-select:hover {
-  border-color: #cbd5e1;
+  border-color: #1a3e6a;
+  box-shadow: 0 0 0 3px rgba(26, 62, 106, 0.12);
 }
 
 .results-counter {
-  margin-left: auto;
-  padding: 10px 0;
-  font-size: 0.875rem;
-  color: #64748b;
-  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-weight: 600;
+  color: #1a3e6a;
 }
 
-/* ===== Tabla Mejorada ===== */
-.table-container {
-  background: white;
+.stats-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  background: #ffffff;
   border-radius: 12px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  padding: 1.25rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.stat-icon {
+  font-size: 1.8rem;
+}
+
+.stat-info h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #1a3e6a;
+}
+
+.stat-info p {
+  margin: 0;
+  color: #6c757d;
+}
+
+.table-container {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
   overflow: hidden;
 }
 
@@ -726,29 +146,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 24px;
-  border-bottom: 1px solid #f1f5f9;
-  background: #fafbfc;
-}
-
-.table-header h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #1e293b;
-  margin: 0;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e9ecef;
 }
 
 .table-stats {
   display: flex;
-  gap: 16px;
-}
-
-.stat-item {
-  font-size: 0.875rem;
-  color: #64748b;
-  padding: 4px 8px;
-  background: #f1f5f9;
-  border-radius: 6px;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: #6c757d;
+  font-weight: 600;
 }
 
 .table-wrapper {
@@ -758,374 +165,183 @@
 .data-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e9ecef;
 }
 
 .data-table th {
-  background: #f8fafc;
+  background: #f8f9fa;
   font-weight: 600;
-  color: #475569;
-  text-align: left;
-  padding: 16px 20px;
-  border-bottom: 2px solid #e2e8f0;
-  white-space: nowrap;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.data-table th.sortable {
-  cursor: pointer;
-  user-select: none;
-  transition: background-color 0.2s ease;
-}
-
-.data-table th.sortable:hover {
-  background: #f1f5f9;
-}
-
-.data-table th.sortable span {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  color: #1a3e6a;
 }
 
 .sort-icon {
-  font-size: 0.75rem;
-  color: #94a3b8;
-  opacity: 0.6;
-  transition: opacity 0.2s ease;
+  margin-left: 0.5rem;
+  color: #adb5bd;
 }
 
-.data-table th.sortable:hover .sort-icon {
-  opacity: 1;
+.table-row.high-completion {
+  background: rgba(0, 140, 74, 0.05);
 }
 
-.data-table td {
-  padding: 16px 20px;
-  border-bottom: 1px solid #f1f5f9;
-  vertical-align: middle;
-}
-
-.table-row {
-  transition: background-color 0.2s ease;
-}
-
-.table-row:hover {
-  background: #f8fafc;
-}
-
-.table-row.has-comments {
-  border-left: 3px solid #f59e0b;
-}
-
-/* ===== Celdas específicas ===== */
-.docente-cell {
-  min-width: 200px;
+.table-row.low-completion {
+  background: rgba(220, 53, 69, 0.05);
 }
 
 .docente-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .docente-name {
   font-weight: 600;
-  color: #1e293b;
-  font-size: 0.95rem;
+  color: #1a3e6a;
 }
 
 .docente-details {
-  color: #64748b;
-  font-size: 0.8rem;
+  color: #6c757d;
 }
 
-.status-cell {
-  text-align: center;
-  min-width: 120px;
+.students-count {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
-.status-badge {
-  padding: 6px 12px;
-  border-radius: 20px;
-  font-size: 0.8rem;
+.count-number {
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.progress-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.progress-bar {
+  height: 10px;
+  background: #e9ecef;
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 9999px;
+  transition: width 0.3s ease;
+  background: linear-gradient(90deg, #1a3e6a, #00a35c);
+}
+
+.progress-fill.progreso-alto {
+  background: linear-gradient(90deg, #00a35c, #1a3e6a);
+}
+
+.progress-fill.progreso-medio {
+  background: linear-gradient(90deg, #ffc107, #ff9800);
+}
+
+.progress-fill.progreso-bajo {
+  background: linear-gradient(90deg, #ff7043, #e53935);
+}
+
+.progress-fill.sin-progreso {
+  background: #e9ecef;
+}
+
+.progress-text {
+  display: flex;
+  gap: 0.5rem;
+  color: #6c757d;
+  font-size: 0.9rem;
+}
+
+.date-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.date-text {
+  color: #1f2933;
+}
+
+.date-warning .date-text {
+  color: #d48b00;
+}
+
+.date-overdue .date-text {
+  color: #dc3545;
+}
+
+.date-badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
   font-weight: 600;
-  display: inline-block;
-  text-align: center;
-  min-width: 90px;
-  text-transform: capitalize;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
-.status-completado {
-  background-color: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
+.date-badge.warning {
+  background: rgba(255, 193, 7, 0.15);
+  color: #d48b00;
 }
 
-.status-revision {
-  background-color: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fde68a;
-}
-
-.status-pendiente {
-  background-color: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
-}
-
-.status-validador {
-  background-color: #dbeafe;
-  color: #1d4ed8;
-  border: 1px solid #bfdbfe;
-}
-
-.comments-cell {
-  max-width: 250px;
-  min-width: 180px;
-}
-
-.comments-container {
-  font-size: 0.875rem;
-  color: #4b5563;
-  line-height: 1.4;
-  word-wrap: break-word;
-}
-
-.no-comments {
-  color: #9ca3af;
-  font-style: italic;
-}
-
-.actions-cell {
-  text-align: center;
-  min-width: 120px;
+.date-badge.overdue {
+  background: rgba(220, 53, 69, 0.15);
+  color: #dc3545;
 }
 
 .action-buttons {
   display: flex;
-  gap: 8px;
-  justify-content: center;
-}
-
-/* ===== Botones Mejorados ===== */
-.btn {
-  border: none;
-  cursor: pointer;
-  border-radius: 8px;
-  padding: 10px 16px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: all 0.2s ease;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  text-decoration: none;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-}
-
-.btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-
-.btn:active {
-  transform: translateY(0);
-}
-
-.btn-primary {
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
-  color: white;
-  border: 1px solid transparent;
-}
-
-.btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
-}
-
-.btn-secondary {
-  background: white;
-  color: #374151;
-  border: 1px solid #d1d5db;
-}
-
-.btn-secondary:hover {
-  background: #f9fafb;
-  border-color: #9ca3af;
-}
-
-.btn-sm {
-  padding: 6px 12px;
-  font-size: 0.8rem;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .action-btn {
-  min-width: 80px;
-  justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
-.icon {
-  font-size: 0.875rem;
-}
-
-/* ===== Estados vacíos ===== */
 .no-data-message {
-  padding: 60px 20px;
+  padding: 3rem 2rem;
   text-align: center;
-  color: #64748b;
-}
-
-.no-data-content {
-  max-width: 400px;
-  margin: 0 auto;
+  color: #6c757d;
 }
 
 .no-data-icon {
-  font-size: 3rem;
-  margin-bottom: 16px;
+  font-size: 2rem;
   display: block;
+  margin-bottom: 0.5rem;
 }
 
-.no-data-content h3 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #475569;
-  margin: 0 0 8px 0;
-}
-
-.no-data-content p {
-  font-size: 0.95rem;
-  color: #64748b;
-  margin: 0;
-}
-
-/* ===== Footer de tabla ===== */
 .table-footer {
-  padding: 16px 24px;
-  background: #f8fafc;
-  border-top: 1px solid #e2e8f0;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid #e9ecef;
+  gap: 1rem;
 }
 
 .pagination-info {
-  font-size: 0.875rem;
-  color: #64748b;
-}
-
-/* ===== Responsivo ===== */
-@media (max-width: 1200px) {
-  .filters-section {
-    flex-direction: column;
-    gap: 16px;
-    align-items: stretch;
-  }
-
-  .filter-group {
-    min-width: auto;
-  }
-
-  .results-counter {
-    margin-left: 0;
-    text-align: center;
-  }
+  color: #6c757d;
 }
 
 @media (max-width: 768px) {
-  .content {
-    padding: 16px;
-  }
-
-  .page-header {
+  .table-stats {
     flex-direction: column;
-    gap: 16px;
-    align-items: stretch;
+    align-items: flex-start;
   }
 
-  .header-actions {
+  .table-footer {
     flex-direction: column;
-    gap: 8px;
+    align-items: flex-start;
   }
-
-  .table-container {
-    border-radius: 8px;
-  }
-
-  .data-table th,
-  .data-table td {
-    padding: 12px 16px;
-  }
-
-  .status-badge {
-    min-width: auto;
-    font-size: 0.75rem;
-    padding: 4px 8px;
-  }
-
-  .docente-name {
-    font-size: 0.9rem;
-  }
-
-  .docente-details {
-    font-size: 0.75rem;
-  }
-}
-
-/* ===== Mejoras visuales adicionales ===== */
-.table-row:nth-child(even) {
-  background: rgba(248, 250, 252, 0.5);
-}
-
-.table-row:nth-child(even):hover {
-  background: #f1f5f9;
-}
-
-/* Animaciones sutiles */
-.status-badge {
-  animation: fadeIn 0.3s ease-in-out;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Mejora en el enfoque para accesibilidad */
-.btn:focus,
-.filter-select:focus {
-  outline: 2px solid #3b82f6;
-  outline-offset: 2px;
-}
-
-/* Indicador de carga (para futuras implementaciones) */
-.loading {
-  opacity: 0.6;
-  pointer-events: none;
-}
-
-/* Tooltip personalizado */
-[title] {
-  position: relative;
-  cursor: help;
-}
-
-/* Mejoras en el contraste para mejor legibilidad */
-.data-table th {
-  font-size: 0.85rem;
-  letter-spacing: 0.025em;
-  text-transform: uppercase;
-}
-
-.data-table td {
-  font-size: 0.9rem;
-  line-height: 1.5;
 }

--- a/frontend/src/app/features/coordinacion/Docentes/docentes.component.html
+++ b/frontend/src/app/features/coordinacion/Docentes/docentes.component.html
@@ -1,298 +1,237 @@
-<!-- FRONTEND DE DOCENTES - PANEL DE FEEDBACK ESTUDIANTIL -->
-<div class="dashboard">
-  <!-- Sidebar -->
-  <aside class="sidebar" [ngClass]="{'open': menuOpen, 'closed': !menuOpen}">
-    <div class="logo-container" (click)="menuOpen ? null : toggleMenu()">
-      <img src="assets/utem.png" alt="Logo UTEM" class="logo-image" />
-      <h3 class="logo-title" [class.hidden]="!menuOpen">PROCESO DE TITULACIÓN</h3>
+<section class="docentes-page">
+  <div class="page-header">
+    <div class="title-section">
+      <h1 class="title">Panel del Coordinador</h1>
+      <p class="subtitle">Sistema de Feedback Estudiantil - Evaluación Docente</p>
+    </div>
+    <div class="header-actions">
+      <button class="btn btn-secondary" type="button" (click)="exportExcel()">
+        <i class="icon">📊</i>
+        Exportar Excel
+      </button>
+      <button class="btn btn-secondary" type="button" (click)="exportPDF()">
+        <i class="icon">📄</i>
+        Exportar PDF
+      </button>
+    </div>
+  </div>
+
+  <div class="filters-section">
+    <div class="filter-group">
+      <label for="cohorte">Cohorte</label>
+      <select
+        id="cohorte"
+        class="filter-select"
+        [(ngModel)]="selectedCohorte"
+        (change)="applyFilters()"
+      >
+        <option value="">Seleccionar cohorte</option>
+        <option *ngFor="let cohorte of cohortes" [value]="cohorte">{{ cohorte }}</option>
+      </select>
     </div>
 
-    <div class="menu-toggle" (click)="toggleMenu()" [attr.aria-label]="menuOpen ? 'Cerrar menú' : 'Abrir menú'">
-      <span class="toggle-icon" [class.rotated]="!menuOpen">☰</span>
+    <div class="filter-group">
+      <label for="semestre">Semestre</label>
+      <select
+        id="semestre"
+        class="filter-select"
+        [(ngModel)]="selectedSemestre"
+        (change)="applyFilters()"
+      >
+        <option value="">Seleccionar semestre</option>
+        <option *ngFor="let semestre of semestres" [value]="semestre">{{ semestre }}</option>
+      </select>
     </div>
 
-    <nav class="navigation">
-      <ul>
-        <li class="nav-item" (click)="navigateTo('notificaciones')">
-          <img src="assets/Notificaciones.png" alt="Notificaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Notificaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('bandeja')">
-          <img src="assets/Bandeja_entrada.png" alt="Bandeja de entrada" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Bandeja de Entrada</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('inicio')">
-          <img src="assets/Inicio.png" alt="Inicio" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Inicio</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('estudiantes')">
-          <img src="assets/Estudiantes.png" alt="Estudiantes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Estudiantes</span>
-        </li>
-        <li class="nav-item active" (click)="navigateTo('docentes')">
-          <img src="assets/Docentes.png" alt="Docentes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Docentes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('procesos')">
-          <img src="assets/Procesos.png" alt="Procesos" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Procesos</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('evaluaciones')">
-          <img src="assets/Evaluaciones.png" alt="Evaluaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Evaluaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('reportes')">
-          <img src="assets/Reportes.png" alt="Reportes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Reportes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('perfil')">
-          <img src="assets/Perfil.png" alt="Perfil" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Perfil</span>
-        </li>
-        <li class="nav-item logout" (click)="logout()">
-          <img src="assets/Cerrar_Sesion.png" alt="Cerrar sesión" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Cerrar Sesión</span>
-        </li>
-      </ul>
-    </nav>
-  </aside>
-
-  <!-- Contenido Principal -->
-  <main class="content" [style.margin-left.px]="menuOpen ? 110 : 65">
-    <!-- Header -->
-    <div class="page-header">
-      <div class="title-section">
-        <h1 class="title">Panel del Coordinador</h1>
-        <p class="subtitle">Sistema de Feedback Estudiantil - Evaluación Docente</p>
-      </div>
-      <div class="header-actions">
-        <button class="btn btn-secondary" (click)="exportExcel()">
-          <i class="icon">📊</i>
-          Exportar Excel
-        </button>
-        <button class="btn btn-secondary" (click)="exportPDF()">
-          <i class="icon">📄</i>
-          Exportar PDF
-        </button>
-      </div>
+    <div class="filter-group">
+      <label for="proceso">Tipo de proceso</label>
+      <select
+        id="proceso"
+        class="filter-select"
+        [(ngModel)]="selectedProceso"
+        (change)="applyFilters()"
+      >
+        <option value="">Seleccionar proceso</option>
+        <option *ngFor="let proceso of procesos" [value]="proceso">{{ proceso }}</option>
+      </select>
     </div>
 
-    <!-- Filtros -->
-    <div class="filters-section">
-      <div class="filter-group">
-        <label for="cohorte">Cohorte</label>
-        <select 
-          id="cohorte"
-          class="filter-select" 
-          [(ngModel)]="selectedCohorte" 
-          (change)="applyFilters()">
-          <option value="">Seleccionar cohorte</option>
-          <option *ngFor="let cohorte of cohortes" [value]="cohorte">{{ cohorte }}</option>
-        </select>
-      </div>
+    <div class="results-counter">
+      <span>{{ filteredDocentes.length }} docentes encontrados</span>
+    </div>
+  </div>
 
-      <div class="filter-group">
-        <label for="semestre">Semestre</label>
-        <select 
-          id="semestre"
-          class="filter-select" 
-          [(ngModel)]="selectedSemestre" 
-          (change)="applyFilters()">
-          <option value="">Seleccionar semestre</option>
-          <option *ngFor="let semestre of semestres" [value]="semestre">{{ semestre }}</option>
-        </select>
+  <div class="stats-section">
+    <div class="stat-card">
+      <div class="stat-icon">👥</div>
+      <div class="stat-info">
+        <h3>{{ getEstadisticasEncuestas().totalEstudiantes }}</h3>
+        <p>Total Estudiantes</p>
       </div>
-
-      <div class="filter-group">
-        <label for="proceso">Tipo de proceso</label>
-        <select 
-          id="proceso"
-          class="filter-select" 
-          [(ngModel)]="selectedProceso" 
-          (change)="applyFilters()">
-          <option value="">Seleccionar proceso</option>
-          <option *ngFor="let proceso of procesos" [value]="proceso">{{ proceso }}</option>
-        </select>
+    </div>
+    <div class="stat-card">
+      <div class="stat-icon">✅</div>
+      <div class="stat-info">
+        <h3>{{ getEstadisticasEncuestas().totalEncuestasCompletadas }}</h3>
+        <p>Encuestas Completadas</p>
       </div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-icon">📊</div>
+      <div class="stat-info">
+        <h3>{{ getEstadisticasEncuestas().promedioCompletado }}%</h3>
+        <p>Promedio Completado</p>
+      </div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-icon">🎯</div>
+      <div class="stat-info">
+        <h3>{{ getEstadisticasEncuestas().completadas }}</h3>
+        <p>Procesos Terminados</p>
+      </div>
+    </div>
+  </div>
 
-      <div class="results-counter">
-        <span>{{ filteredDocentes.length }} docentes encontrados</span>
+  <div class="table-container">
+    <div class="table-header">
+      <h2>Gestión de Feedback Docente</h2>
+      <div class="table-stats">
+        <span class="stat-item">Total: {{ getTotalDocentes() }}</span>
+        <span class="stat-item">Completadas: {{ getEstadisticasEncuestas().completadas }}</span>
+        <span class="stat-item">En Progreso: {{ getEstadisticasEncuestas().enProgreso }}</span>
       </div>
     </div>
 
-    <!-- Estadísticas Generales -->
-    <div class="stats-section">
-      <div class="stat-card">
-        <div class="stat-icon">👥</div>
-        <div class="stat-info">
-          <h3>{{ getEstadisticasEncuestas().totalEstudiantes }}</h3>
-          <p>Total Estudiantes</p>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-icon">✅</div>
-        <div class="stat-info">
-          <h3>{{ getEstadisticasEncuestas().totalEncuestasCompletadas }}</h3>
-          <p>Encuestas Completadas</p>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-icon">📊</div>
-        <div class="stat-info">
-          <h3>{{ getEstadisticasEncuestas().promedioCompletado }}%</h3>
-          <p>Promedio Completado</p>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-icon">🎯</div>
-        <div class="stat-info">
-          <h3>{{ getEstadisticasEncuestas().completadas }}</h3>
-          <p>Procesos Terminados</p>
+    <div class="table-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th class="sortable">
+              <span>Docente</span>
+              <i class="sort-icon">↕</i>
+            </th>
+            <th class="sortable">
+              <span>Número de estudiantes</span>
+              <i class="sort-icon">↕</i>
+            </th>
+            <th class="sortable">
+              <span>Inicio</span>
+              <i class="sort-icon">↕</i>
+            </th>
+            <th class="sortable">
+              <span>Encuestas Completadas</span>
+              <i class="sort-icon">↕</i>
+            </th>
+            <th class="sortable">
+              <span>Entrega Final</span>
+              <i class="sort-icon">↕</i>
+            </th>
+            <th class="sortable">
+              <span>Cierre</span>
+              <i class="sort-icon">↕</i>
+            </th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            *ngFor="let docente of filteredDocentes; trackBy: trackByDocenteId"
+            class="table-row"
+            [class.high-completion]="docente.porcentajeCompletado >= 70"
+            [class.low-completion]="docente.porcentajeCompletado < 40"
+          >
+            <td class="docente-cell">
+              <div class="docente-info">
+                <span class="docente-name">{{ docente.nombre }}</span>
+                <small class="docente-details">{{ docente.cohorte }} - {{ docente.semestre }}</small>
+              </div>
+            </td>
+            <td class="students-cell">
+              <div class="students-count">
+                <span class="count-number">{{ docente.numeroEstudiantes }}</span>
+                <span class="count-label">estudiantes</span>
+              </div>
+            </td>
+            <td class="date-cell">
+              <div class="date-info">
+                <span class="date-text">{{ formatDate(docente.fechaInicio) }}</span>
+              </div>
+            </td>
+            <td class="progress-cell">
+              <div class="progress-container">
+                <div class="progress-bar">
+                  <div
+                    class="progress-fill"
+                    [style.width.%]="docente.porcentajeCompletado"
+                    [class]="getProgressStatus(docente.porcentajeCompletado)"
+                  ></div>
+                </div>
+                <div class="progress-text">
+                  <span class="completion-count">{{ docente.encuestasCompletadas }}/{{ docente.numeroEstudiantes }}</span>
+                  <span class="completion-percentage">({{ docente.porcentajeCompletado }}%)</span>
+                </div>
+              </div>
+            </td>
+            <td class="date-cell">
+              <div
+                class="date-info"
+                [class.date-warning]="isDateNearDeadline(docente.fechaEntregaFinal)"
+                [class.date-overdue]="isDateOverdue(docente.fechaEntregaFinal)"
+              >
+                <span class="date-text">{{ formatDate(docente.fechaEntregaFinal) }}</span>
+                <span *ngIf="isDateNearDeadline(docente.fechaEntregaFinal)" class="date-badge warning">Próximo</span>
+                <span *ngIf="isDateOverdue(docente.fechaEntregaFinal)" class="date-badge overdue">Vencido</span>
+              </div>
+            </td>
+            <td class="date-cell">
+              <div class="date-info">
+                <span class="date-text">{{ formatDate(docente.fechaCierre) }}</span>
+              </div>
+            </td>
+            <td class="actions-cell">
+              <div class="action-buttons">
+                <button
+                  class="btn btn-primary btn-sm action-btn"
+                  type="button"
+                  (click)="verDetallesRespuestas(docente)"
+                  [title]="'Ver detalles de feedback de ' + docente.nombre"
+                >
+                  <i class="icon">👁</i>
+                  Ver Detalles
+                </button>
+                <button
+                  class="btn btn-secondary btn-sm action-btn"
+                  type="button"
+                  *ngIf="docente.porcentajeCompletado < 100"
+                  (click)="enviarRecordatorio(docente)"
+                  [title]="'Enviar recordatorio a estudiantes'"
+                >
+                  <i class="icon">📧</i>
+                  Recordatorio
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div *ngIf="filteredDocentes.length === 0" class="no-data-message">
+        <div class="no-data-content">
+          <i class="no-data-icon">👨‍🏫</i>
+          <h3>No se encontraron docentes</h3>
+          <p>Intenta cambiar los filtros para ver más resultados</p>
         </div>
       </div>
     </div>
 
-    <!-- Tabla -->
-    <div class="table-container">
-      <div class="table-header">
-        <h2>Gestión de Feedback Docente</h2>
-        <div class="table-stats">
-          <span class="stat-item">Total: {{ getTotalDocentes() }}</span>
-          <span class="stat-item">Completadas: {{ getEstadisticasEncuestas().completadas }}</span>
-          <span class="stat-item">En Progreso: {{ getEstadisticasEncuestas().enProgreso }}</span>
-        </div>
+    <div class="table-footer" *ngIf="filteredDocentes.length > 0">
+      <div class="pagination-info">
+        Mostrando {{ filteredDocentes.length }} de {{ docentes.length }} docentes
       </div>
-
-      <div class="table-wrapper">
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th class="sortable">
-                <span>Docente</span>
-                <i class="sort-icon">↕</i>
-              </th>
-              <th class="sortable">
-                <span>Número de estudiantes</span>
-                <i class="sort-icon">↕</i>
-              </th>
-              <th class="sortable">
-                <span>Inicio</span>
-                <i class="sort-icon">↕</i>
-              </th>
-              <th class="sortable">
-                <span>Encuestas Completadas</span>
-                <i class="sort-icon">↕</i>
-              </th>
-              <th class="sortable">
-                <span>Entrega Final</span>
-                <i class="sort-icon">↕</i>
-              </th>
-              <th class="sortable">
-                <span>Cierre</span>
-                <i class="sort-icon">↕</i>
-              </th>
-              <th>Acciones</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr *ngFor="let docente of filteredDocentes; trackBy: trackByDocenteId" 
-                class="table-row"
-                [class.high-completion]="docente.porcentajeCompletado >= 70"
-                [class.low-completion]="docente.porcentajeCompletado < 40">
-              
-              <td class="docente-cell">
-                <div class="docente-info">
-                  <span class="docente-name">{{ docente.nombre }}</span>
-                  <small class="docente-details">{{ docente.cohorte }} - {{ docente.semestre }}</small>
-                </div>
-              </td>
-
-              <td class="students-cell">
-                <div class="students-count">
-                  <span class="count-number">{{ docente.numeroEstudiantes }}</span>
-                  <span class="count-label">estudiantes</span>
-                </div>
-              </td>
-
-              <td class="date-cell">
-                <div class="date-info">
-                  <span class="date-text">{{ formatDate(docente.fechaInicio) }}</span>
-                </div>
-              </td>
-
-              <td class="progress-cell">
-                <div class="progress-container">
-                  <div class="progress-bar">
-                    <div class="progress-fill" 
-                         [style.width.%]="docente.porcentajeCompletado"
-                         [class]="getProgressStatus(docente.porcentajeCompletado)"></div>
-                  </div>
-                  <div class="progress-text">
-                    <span class="completion-count">{{ docente.encuestasCompletadas }}/{{ docente.numeroEstudiantes }}</span>
-                    <span class="completion-percentage">({{ docente.porcentajeCompletado }}%)</span>
-                  </div>
-                </div>
-              </td>
-
-              <td class="date-cell">
-                <div class="date-info" 
-                     [class.date-warning]="isDateNearDeadline(docente.fechaEntregaFinal)"
-                     [class.date-overdue]="isDateOverdue(docente.fechaEntregaFinal)">
-                  <span class="date-text">{{ formatDate(docente.fechaEntregaFinal) }}</span>
-                  <span *ngIf="isDateNearDeadline(docente.fechaEntregaFinal)" class="date-badge warning">Próximo</span>
-                  <span *ngIf="isDateOverdue(docente.fechaEntregaFinal)" class="date-badge overdue">Vencido</span>
-                </div>
-              </td>
-
-              <td class="date-cell">
-                <div class="date-info">
-                  <span class="date-text">{{ formatDate(docente.fechaCierre) }}</span>
-                </div>
-              </td>
-
-              <td class="actions-cell">
-                <div class="action-buttons">
-                  <button 
-                    class="btn btn-primary btn-sm action-btn"
-                    (click)="verDetallesRespuestas(docente)"
-                    [title]="'Ver detalles de feedback de ' + docente.nombre">
-                    <i class="icon">👁</i>
-                    Ver Detalles
-                  </button>
-                  <button 
-                    class="btn btn-secondary btn-sm action-btn"
-                    *ngIf="docente.porcentajeCompletado < 100"
-                    (click)="enviarRecordatorio(docente)"
-                    [title]="'Enviar recordatorio a estudiantes'">
-                    <i class="icon">📧</i>
-                    Recordatorio
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <!-- Mensaje cuando no hay datos -->
-        <div *ngIf="filteredDocentes.length === 0" class="no-data-message">
-          <div class="no-data-content">
-            <i class="no-data-icon">👨‍🏫</i>
-            <h3>No se encontraron docentes</h3>
-            <p>Intenta cambiar los filtros para ver más resultados</p>
-          </div>
-        </div>
-      </div>
-
-      <!-- Paginación -->
-      <div class="table-footer" *ngIf="filteredDocentes.length > 0">
-        <div class="pagination-info">
-          Mostrando {{ filteredDocentes.length }} de {{ docentes.length }} docentes
-        </div>
-        <button class="btn btn-secondary btn-sm" (click)="resetFilters()">
-          <i class="icon">🔄</i>
-          Limpiar Filtros
-        </button>
-      </div>
+      <button class="btn btn-secondary btn-sm" type="button" (click)="resetFilters()">
+        <i class="icon">🔄</i>
+        Limpiar Filtros
+      </button>
     </div>
-  </main>
-</div>
+  </div>
+</section>

--- a/frontend/src/app/features/coordinacion/Docentes/docentes.component.ts
+++ b/frontend/src/app/features/coordinacion/Docentes/docentes.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
-import { AuthService } from '../../../auth.service';
 
 interface Docente {
   id: number;
@@ -26,8 +24,6 @@ interface Docente {
   styleUrls: ['./docentes.component.css']
 })
 export class CoordinacionDocentesComponent implements OnInit {
-  // Estado del menú
-  menuOpen = true;
 
   // Filtros
   cohortes: string[] = ['2019', '2020', '2021', '2022', '2023'];
@@ -136,8 +132,6 @@ export class CoordinacionDocentesComponent implements OnInit {
       fechaCierre: '2024-09-20'
     }
   ];
-  constructor(private readonly authService: AuthService, private readonly router: Router) {}
-
   // Inicialización del componente
   ngOnInit(): void {
     this.loadDocentes();
@@ -213,26 +207,6 @@ export class CoordinacionDocentesComponent implements OnInit {
   exportPDF(): void {
     console.log('Exportando datos de feedback docente a PDF...');
     alert('Exportando reporte de encuestas de feedback docente a PDF');
-  }
-
-  // ===== Métodos del Sidebar =====
-  toggleMenu(): void {
-    this.menuOpen = !this.menuOpen;
-  }
-
-  navigateTo(section: string): void {
-    console.log(`Navegando a sección: ${section}`);
-    // Aquí implementarías la navegación real usando Router
-  }
-
-  logout(): void {
-    if (!confirm('¿Estás seguro de que quieres cerrar sesión?')) {
-      return;
-    }
-      this.authService.logout().subscribe({
-      next: () => this.router.navigateByUrl('/auth/login'),
-      error: () => this.router.navigateByUrl('/auth/login'),
-    });
   }
 
   // Método para obtener el número total de docentes filtrados

--- a/frontend/src/app/features/coordinacion/Notificacion/notificacion.component.css
+++ b/frontend/src/app/features/coordinacion/Notificacion/notificacion.component.css
@@ -1,249 +1,26 @@
-/* =======================
-   DASHBOARD + SIDEBAR
-   ======================= */
-
-.dashboard {
-  display: flex;
-  min-height: 100vh;
+:host {
+  display: block;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f5f5f5;
 }
 
-/* Sidebar */
-.sidebar {
-  width: 110px; /* Reducido de 170px a 110px */
-  background: linear-gradient(180deg, #301e30 0%, #2a1a2a 100%);
-  color: white;
-  padding: 0;
+.notificaciones-page {
   display: flex;
   flex-direction: column;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-  position: fixed; /* CAMBIADO: Ahora es fijo */
-  top: 0;
-  left: 0;
-  height: 100vh; /* Altura completa de la ventana */
-  z-index: 1000;
-  overflow: hidden;
+  gap: 1.5rem;
 }
 
-.sidebar.closed {
-  width: 65px; /* Ajustado proporcionalmente */
-}
-
-.logo-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0.5rem 1.5rem 0.2rem; /* Aumentado padding superior para dar espacio al toggle */
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  min-height: 100px; /* Aumentado ligeramente */
-  justify-content: center;
-  position: relative;
-}
-
-.logo-image {
-  width: 52px;
-  height: 65px;
-  object-fit: contain;
-  margin-bottom: 0.3rem;
-  transition: all 0.3s ease;
-}
-.sidebar.closed .logo-image {
-  width: 31px;
-  height: 41px;
-}
-
-.logo-title {
-  font-size: 0.6rem; /* Reducido de 0.7rem a 0.6rem */
-  font-weight: 600;
-  color: #008c6e;
+.ttl {
+  color: #1a3e6a;
   margin: 0;
-  text-align: center;
-  line-height: 1; /* Líneas más compactas */
-  transition: all 0.3s ease;
-  white-space: normal; /* Permitir que el texto se divida en líneas */
-  max-width: 90px; /* Aumentado el ancho máximo */
-  word-wrap: break-word; /* Dividir palabras largas si es necesario */
-  hyphens: auto; /* Guiones automáticos */
-}
-
-.logo-title.hidden {
-  opacity: 0;
-  transform: translateY(-10px);
-}
-
-/* Navegación optimizada - con scroll interno */
-.navigation {
-  flex: 1;
-  padding: 1rem 0;
-  overflow-y: auto; /* Permitir scroll interno si hay muchos elementos */
-  overflow-x: hidden;
-  opacity: 1;
-  transition: all 0.3s ease;
-}
-
-/* Personalizar scrollbar del menú */
-.navigation::-webkit-scrollbar {
-  width: 4px;
-}
-
-.navigation::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.navigation::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 2px;
-}
-
-.navigation::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.5);
-}
-
-/* Ocultar completamente la navegación cuando está cerrado */
-.sidebar.closed .navigation {
-  opacity: 0;
-  visibility: hidden;
-  height: 0;
-  padding: 0;
-}
-
-.navigation ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.nav-item {
-  margin: 0.01rem 1rem; /* Margen vertical*/
-  padding: 0.5rem; /* Tamaño Borde Opcion del menu*/
-  cursor: pointer;
-  display: flex;
-  flex-direction: column; /* CAMBIO: Columna en lugar de fila */
-  align-items: center;
-  gap: 0.4rem; /* Distancia Letras Icono */
-  border-radius: 8px;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  text-align: center; /* Centrar el texto */
-}
-
-/* Eliminar la regla específica para sidebar.closed .nav-item ya que estará oculto */
-
-.nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
-  transform: translateY(-2px); /* Cambio de dirección para que sea consistente con el layout vertical */
-}
-
-/* Estilo para el elemento activo en el menú */
-.nav-item.active {
-  background: rgba(255, 255, 255, 0.15);
-  border-left: 3px solid #00548c;
-}
-
-.nav-item.active .menu-icon {
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(0, 140, 74, 0.8));
-}
-
-.nav-item:active {
-  transform: translateY(-1px) scale(0.98);
-}
-
-.nav-item.logout {
-  margin-top: 0.4rem; /* Linea separadora Perfil - Cerrar Sesion */
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 0.4rem;
-}
-
-.nav-item.logout:hover {
-  background: rgba(220, 53, 69, 0.2);
-}
-
-/* Estilos específicos para los iconos del menú */
-.menu-icon {
-  width: 25px; /* Reducido de 22px a 18px */
-  height: 25px;
-  object-fit: contain;
-  transition: all 0.3s ease;
-  filter: brightness(0) invert(1);
-  margin-bottom: 0rem;
-}
-
-/* Ajustar tamaño cuando el menú está cerrado */
-.sidebar.closed .menu-icon {
-  width: 16px; /* Reducido de 20px a 16px */
-  height: 16px;
-  margin-bottom: 0;
-}
-
-/* Hover effect para los iconos */
-.nav-item:hover .menu-icon {
-  transform: scale(1.3);
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(255, 255, 255, 0.5));
-}
-
-/* Icono especial para logout */
-.nav-item.logout:hover .menu-icon {
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(220, 53, 69, 0.8));
-}
-
-/* Navegación */
-.navigation { flex: 1; padding: 1rem 0; overflow-y: auto; }
-.navigation ul { list-style: none; padding: 0; margin: 0; }
-
-/* Contenido */
-.content {
-  flex: 1;
-  padding: 2rem;
-  background: #f8f9fa;
-  margin-left: 110px;
-  transition: margin-left 0.3s ease;
-}
-.sidebar.closed + .content { margin-left: 65px; }
-
-/* Botón toggle */
-.menu-toggle {
-  position: absolute;
-  top: 6.6rem;
-  right: 0.1rem;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 50%;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.menu-toggle:hover { background: rgba(255, 255, 255, 0.2); transform: scale(1.1); }
-
-.label {
-  font-size: 0.55rem;
-  font-weight: 500;
-  white-space: nowrap;
-  text-align: center;
-  max-width: 90px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.label.hidden { opacity: 0; transform: translateY(-8px); }
-
-/* =======================
-   NOTIFICACIONES
-   ======================= */
-.ttl { 
-  color: #1a3e6a; 
-  margin-bottom: 20px; 
   font-size: 1.5rem;
   font-weight: 600;
 }
 
-.filters { 
-  margin: 10px 0 20px; 
+.filters {
   display: flex;
   gap: 20px;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .filter-group {
@@ -262,12 +39,12 @@
   padding: 6px 12px;
   border: 1px solid #d1d5db;
   border-radius: 6px;
-  background: white;
+  background: #ffffff;
   color: #374151;
   font-size: 0.9rem;
-  min-width: 120px;
+  min-width: 140px;
   cursor: pointer;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .filter-group select:hover {
@@ -277,36 +54,36 @@
 .filter-group select:focus {
   outline: none;
   border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
 }
 
-.notis { 
-  list-style: none; 
-  margin: 0; 
-  padding: 0; 
-  display: grid; 
-  gap: 8px; 
+.notis {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
 }
 
 .notis li {
   display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
-  background: #fff;
+  background: #ffffff;
   border: 1px solid var(--utem-border, #dfe5ee);
   border-radius: 10px;
   padding: 16px 18px;
-  box-shadow: 0 6px 24px var(--utem-shadow, rgba(0,0,0,0.05));
+  box-shadow: 0 6px 24px var(--utem-shadow, rgba(0, 0, 0, 0.05));
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .notis li:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 30px rgba(0,0,0,0.08);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.08);
 }
 
-.ic { 
-  font-size: 18px; 
+.ic {
+  font-size: 18px;
   margin-right: 12px;
   display: flex;
   align-items: center;
@@ -324,15 +101,15 @@
   line-height: 1.4;
 }
 
-.tm { 
-  color: #6b7280; 
+.tm {
+  color: #6b7280;
   font-size: 0.875rem;
 }
 
 .mark {
   display: inline-block;
-  margin-top: 16px;
-  color: #1976D2;
+  align-self: flex-start;
+  color: #1976d2;
   font-weight: 700;
   text-decoration: none;
   transition: color 0.2s ease;
@@ -342,4 +119,19 @@
 .mark:hover {
   color: #1565c0;
   text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  .filters {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .filter-group {
+    width: 100%;
+  }
+
+  .filter-group select {
+    width: 100%;
+  }
 }

--- a/frontend/src/app/features/coordinacion/Notificacion/notificacion.component.html
+++ b/frontend/src/app/features/coordinacion/Notificacion/notificacion.component.html
@@ -1,98 +1,38 @@
-<div class="dashboard">
-  <!-- Sidebar -->
-  <aside class="sidebar" [ngClass]="{'open': menuOpen, 'closed': !menuOpen}">
-    <div class="logo-container" (click)="menuOpen ? null : toggleMenu()">
-      <img src="assets/utem.png" alt="Logo UTEM" class="logo-image" />
-      <h3 class="logo-title" [class.hidden]="!menuOpen">PROCESO DE TITULACIÓN</h3>
+<section class="notificaciones-page">
+  <h2 class="ttl">Notificaciones</h2>
+
+  <div class="filters">
+    <div class="filter-group">
+      <label>Tipo:</label>
+      <select [(ngModel)]="filtroTipo" (ngModelChange)="onFiltroTipoChange($event)">
+        <option value="todas">Todas</option>
+        <option value="entregas">Entregas</option>
+        <option value="retro">Retro</option>
+        <option value="reuniones">Reuniones</option>
+        <option value="estados">Estados</option>
+      </select>
     </div>
-
-    <div class="menu-toggle" (click)="toggleMenu()" [attr.aria-label]="menuOpen ? 'Cerrar menú' : 'Abrir menú'">
-      <span class="toggle-icon" [class.rotated]="!menuOpen">☰</span>
+    <div class="filter-group">
+      <label>Fecha:</label>
+      <select [(ngModel)]="filtroFecha" (ngModelChange)="onFiltroFechaChange($event)">
+        <option value="todas">Todas</option>
+        <option value="hoy">Hoy</option>
+        <option value="ayer">Ayer</option>
+        <option value="semana">Esta semana</option>
+        <option value="mes">Este mes</option>
+      </select>
     </div>
+  </div>
 
-    <nav class="navigation">
-      <ul>
-        <li class="nav-item" [class.active]="currentView === 'notificaciones'" (click)="navigateTo('notificaciones')">
-          <img src="assets/Notificaciones.png" alt="Notificaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Notificaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('bandeja')">
-          <img src="assets/Bandeja_entrada.png" alt="Bandeja de entrada" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Bandeja de Entrada</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('inicio')">
-          <img src="assets/Inicio.png" alt="Inicio" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Inicio</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('estudiantes')">
-          <img src="assets/Estudiantes.png" alt="Estudiantes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Estudiantes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('docentes')">
-          <img src="assets/Docentes.png" alt="Docentes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Docentes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('procesos')">
-          <img src="assets/Procesos.png" alt="Procesos" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Procesos</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('evaluaciones')">
-          <img src="assets/Evaluaciones.png" alt="Evaluaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Evaluaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('reportes')">
-          <img src="assets/Reportes.png" alt="Reportes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Reportes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('perfil')">
-          <img src="assets/Perfil.png" alt="Perfil" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Perfil</span>
-        </li>
-        <li class="nav-item logout" (click)="logout()">
-          <img src="assets/Cerrar_Sesion.png" alt="Cerrar sesión" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Cerrar Sesión</span>
-        </li>
-      </ul>
-    </nav>
-  </aside>
-
-  <!-- Contenido -->
-  <main class="content">
-    <!-- Vista Notificaciones -->
-    <section *ngIf="currentView==='notificaciones'">
-      <h2 class="ttl">Notificaciones</h2>
-      <div class="filters">
-        <div class="filter-group">
-          <label>Tipo:</label>
-          <select [(ngModel)]="filtroTipo" (ngModelChange)="onFiltroTipoChange($event)">
-            <option value="todas">Todas</option>
-            <option value="entregas">Entregas</option>
-            <option value="retro">Retro</option>
-            <option value="reuniones">Reuniones</option>
-            <option value="estados">Estados</option>
-          </select>
-        </div>
-        <div class="filter-group">
-          <label>Fecha:</label>
-          <select [(ngModel)]="filtroFecha" (ngModelChange)="onFiltroFechaChange($event)">
-            <option value="todas">Todas</option>
-            <option value="hoy">Hoy</option>
-            <option value="ayer">Ayer</option>
-            <option value="semana">Esta semana</option>
-            <option value="mes">Este mes</option>
-          </select>
-        </div>
+  <ul class="notis">
+    <li *ngFor="let n of list">
+      <span class="ic">{{ n.icon }}</span>
+      <div class="noti-content">
+        <span class="tx">{{ n.titulo }}</span>
+        <small class="tm">{{ n.hace }}</small>
       </div>
-      <ul class="notis">
-        <li *ngFor="let n of list">
-          <span class="ic">{{n.icon}}</span>
-          <div class="noti-content">
-            <span class="tx">{{n.titulo}}</span>
-            <small class="tm">{{n.hace}}</small>
-          </div>
-        </li>
-      </ul>
-      <a class="mark" href="javascript:void(0)" (click)="marcarComoLeido()">Marcar como leído</a>
-    </section>
-  </main>
-</div>
+    </li>
+  </ul>
+
+  <a class="mark" href="javascript:void(0)" (click)="marcarComoLeido()">Marcar como leído</a>
+</section>

--- a/frontend/src/app/features/coordinacion/Notificacion/notificacion.component.ts
+++ b/frontend/src/app/features/coordinacion/Notificacion/notificacion.component.ts
@@ -1,8 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
-import { AuthService } from '../../../auth.service';
 
 @Component({
   selector: 'app-notificacion',
@@ -12,20 +10,15 @@ import { AuthService } from '../../../auth.service';
   styleUrls: ['./notificacion.component.css'],
 })
 export class CoordinacionNotificacionComponent {
-  // Estado sidebar
-  menuOpen = true;
-  currentView: string = 'notificaciones'; // vista por defecto
+  readonly items = [
+    { tipo: 'entregas', titulo: 'Entrega 2 vence el 22 abr. 2024', hace: 'hace 20 min', icon: '📅', fecha: 'hoy' },
+    { tipo: 'retro', titulo: 'Retroalimentación disponible para Informe…', hace: 'hace 1 h', icon: '🔵', fecha: 'hoy' },
+    { tipo: 'reuniones', titulo: 'Nueva reunión: 5 de abr. 2024 15:00', hace: 'hace 4 h', icon: '📅', fecha: 'hoy' },
+    { tipo: 'estados', titulo: 'Estado del proceso cambiado a Cierre', hace: 'ayer', icon: '🟡', fecha: 'ayer' },
+  ];
 
-  // Filtros de notificaciones
   filtroTipo: string = 'todas';
   filtroFecha: string = 'todas';
-  
-  items = [
-    { tipo:'entregas',  titulo:'Entrega 2 vence el 22 abr. 2024', hace:'hace 20 min', icon:'📅', fecha: 'hoy' },
-    { tipo:'retro',     titulo:'Retroalimentación disponible para Informe…', hace:'hace 1 h', icon:'🔵', fecha: 'hoy' },
-    { tipo:'reuniones', titulo:'Nueva reunión: 5 de abr. 2024 15:00', hace:'hace 4 h', icon:'📅', fecha: 'hoy' },
-    { tipo:'estados',   titulo:'Estado del proceso cambiado a Cierre', hace:'ayer', icon:'🟡', fecha: 'ayer' },
-  ];
 
   get list() {
     let filteredItems = this.items;
@@ -49,34 +42,6 @@ export class CoordinacionNotificacionComponent {
 
   onFiltroFechaChange(v: string) {
     this.filtroFecha = v;
-  }
-
-  // Funciones menú
-  toggleMenu(): void {
-    this.menuOpen = !this.menuOpen;
-  }
-
-  navigateTo(section: string): void {
-    // Por ahora solo funciona la sección de notificaciones
-    if (section === 'notificaciones') {
-      this.currentView = section;
-    } else {
-      console.log(`Navegando a: ${section} (funcionalidad pendiente)`);
-      // No cambiamos currentView para evitar páginas en blanco
-    }
-  }
-
-   constructor(private readonly authService: AuthService, private readonly router: Router) {}
-
-  logout(): void {
-    if (!confirm('¿Estás seguro de que quieres cerrar sesión?')) {
-      return;
-    }
-
-    this.authService.logout().subscribe({
-      next: () => this.router.navigateByUrl('/auth/login'),
-      error: () => this.router.navigateByUrl('/auth/login'),
-    });
   }
 
   marcarComoLeido(): void {

--- a/frontend/src/app/features/coordinacion/Perfil/perfil.component.css
+++ b/frontend/src/app/features/coordinacion/Perfil/perfil.component.css
@@ -1,195 +1,81 @@
-/* =======================
-   PERFIL + DASHBOARD BASE
-   ======================= */
-
-/* Grid para info personal y edición */
-.info-grid {
-  display: grid;
-  grid-template-columns: 30% 1fr;
-  border: 1px solid #e9ecef;
-  border-radius: 8px;
-  overflow: hidden;
+:host {
+  display: block;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
-.info-row {
-  display: contents;
-}
-
-.label {
-  font-size: 0.55rem; /* Reducido de 0.65rem a 0.55rem */
-  font-weight: 500;
-  transition: all 0.3s ease;
-  white-space: nowrap;
-  text-align: center;
-  line-height: 1;
-  max-width: 90px; /* Limitamos el ancho para evitar overflow */
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.label.hidden {
-  opacity: 0;
-  transform: translateY(-8px);
-}
-
-.info-label {
-  background: #f8f9fa;
-  font-weight: 600;
-  color: #555;
-  padding: 0.8rem 1rem;
-  border-bottom: 1px solid #e9ecef;
-}
-
-.info-value {
-  padding: 0.8rem 1rem;
-  border-bottom: 1px solid #e9ecef;
-  color: #333;
-}
-
-.info-grid .info-row:last-child .info-label,
-.info-grid .info-row:last-child .info-value {
-  border-bottom: none;
-}
-
-/* Responsive info-grid */
-@media (max-width: 600px) {
-  .info-grid {
-    grid-template-columns: 1fr;
-  }
-  .info-label {
-    border-bottom: none;
-    border-top: 1px solid #e9ecef;
-    background: transparent;
-    color: #008c4a;
-  }
-  .info-value {
-    border-top: none;
-    padding-top: 0;
-  }
-}
-
-/* Títulos y contenedor */
-.page-title {
-  color: #666;
-  margin-bottom: 1rem;
-  font-size: 2.5rem;
-  font-weight: 500;
-}
-
-.profile-container {
-  max-width: 800px;
-  margin: 0 auto;
-}
-
-/* Header del perfil */
-.profile-header {
-  display: flex;
-  align-items: center;
-  gap: 10rem;
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
-}
-
-.profile-icon {
-  width: 60px;
-  height: 60px;
-  background: linear-gradient(135deg, #006b8c, #004e6d);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  flex-shrink: 0;
-}
-
-.profile-title h2 {
-  margin: 0;
-  color: #333;
-  font-size: 1.8rem;
-  font-weight: 600;
-}
-
-/* Secciones del perfil */
-.profile-section {
-  background: white;
-  border-radius: 12px;
-  padding: 2rem;
-  margin-bottom: 1.5rem;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
-  transition: all 0.3s ease;
-}
-.profile-section:hover {
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
-}
-
-.section-title {
-  color: #333;
-  font-size: 1.3rem;
-  font-weight: 600;
-  margin: 0 0 1.5rem 0;
-  padding-bottom: 0.5rem;
-  border-bottom: 2px solid #f0f0f0;
-}
-
-/* Formularios */
-.profile-form {
+.perfil-page {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
-.form-row {
+.page-title {
+  color: #666666;
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 500;
+}
+
+.grid {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
 }
 
-.form-group {
-  position: relative;
+.card {
+  background: #ffffff;
+  border: 1px solid var(--utem-border, #dfe5ee);
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 8px 28px var(--utem-shadow, rgba(0, 0, 0, 0.05));
 }
 
-.form-label {
-  display: block;
-  font-weight: 600;
-  color: #555;
-  margin-bottom: 0.5rem;
-  font-size: 0.9rem;
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: #1a3e6a;
 }
 
-.form-value {
-  padding: 0.8rem 1rem;
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
-  border-radius: 8px;
-  color: #333;
-  font-size: 1rem;
-  min-height: 20px;
-}
-
-.form-input {
-  width: 100%;
-  padding: 0.8rem 1rem;
-  border: 2px solid #e9ecef;
-  border-radius: 8px;
-  font-size: 1rem;
-  transition: all 0.3s ease;
-  box-sizing: border-box;
-}
-
-.form-input:focus {
-  outline: none;
-  border-color: #008c4a;
-  box-shadow: 0 0 0 3px rgba(0, 140, 74, 0.1);
-}
-
-/* Botones */
-.form-actions {
-  margin-top: 1rem;
+.row {
   display: flex;
-  justify-content: flex-start;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px dashed #eef3fb;
+}
+
+.row:last-child {
+  border-bottom: 0;
+}
+
+.row b {
+  color: #1a3e6a;
+}
+
+.row span {
+  color: #333333;
+}
+
+.inp {
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+  padding: 8px 10px;
+  flex: 1;
+}
+
+.link {
+  color: #1976d2;
+  font-weight: 700;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+.action-row {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
 }
 
 .btn-edit,
@@ -206,18 +92,20 @@
 
 .btn-edit {
   background: #00598c;
-  color: white;
+  color: #ffffff;
 }
+
 .btn-edit:hover {
   background: hsl(202, 100%, 20%);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 140, 74, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 89, 140, 0.3);
 }
 
 .btn-save {
   background: #00598c;
-  color: white;
+  color: #ffffff;
 }
+
 .btn-save:hover {
   background: #004d8c;
   transform: translateY(-2px);
@@ -225,52 +113,30 @@
 
 .btn-cancel {
   background: #6c757d;
-  color: white;
+  color: #ffffff;
 }
+
 .btn-cancel:hover {
   background: #545b62;
   transform: translateY(-2px);
 }
 
-/* =======================
-   HISTORIAL + SESIONES
-   ======================= */
-
-.session-info {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.session-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-  background: #f8f9fa;
-  border-radius: 8px;
-  border-left: 4px solid #00598c;
-}
-
-.session-label {
-  font-weight: 600;
-  color: #555;
-}
-
-.session-value {
-  color: #333;
-  font-weight: 500;
+.list {
+  margin: 0;
+  padding-left: 16px;
+  color: #333333;
 }
 
 .session-actions {
   display: flex;
   gap: 1rem;
   flex-wrap: wrap;
+  margin-top: 1rem;
 }
 
 .btn-session {
   background: #f8f9fa;
-  color: #333;
+  color: #333333;
   border: 2px solid #e9ecef;
   padding: 0.8rem 1.2rem;
   border-radius: 8px;
@@ -279,6 +145,7 @@
   cursor: pointer;
   transition: all 0.3s ease;
 }
+
 .btn-session:hover {
   background: #e9ecef;
   border-color: #008c4a;
@@ -286,279 +153,13 @@
   transform: translateY(-2px);
 }
 
-/* =======================
-   DASHBOARD + SIDEBAR
-   ======================= */
+@media (max-width: 600px) {
+  .action-row {
+    flex-direction: column;
+  }
 
-.dashboard {
-  display: flex;
-  min-height: 100vh;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f5f5f5;
-}
-
-/* Sidebar */
-.sidebar {
-  width: 110px; /* Reducido de 170px a 110px */
-  background: linear-gradient(180deg, #301e30 0%, #2a1a2a 100%);
-  color: white;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-  position: fixed; /* CAMBIADO: Ahora es fijo */
-  top: 0;
-  left: 0;
-  height: 100vh; /* Altura completa de la ventana */
-  z-index: 1000;
-  overflow: hidden;
-}
-
-.sidebar.closed {
-  width: 65px; /* Ajustado proporcionalmente */
-}
-
-.logo-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0.5rem 1.5rem 0.2rem; /* Aumentado padding superior para dar espacio al toggle */
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  min-height: 100px; /* Aumentado ligeramente */
-  justify-content: center;
-  position: relative;
-}
-
-.logo-image {
-  width: 52px;
-  height: 65px;
-  object-fit: contain;
-  margin-bottom: 0.3rem;
-  transition: all 0.3s ease;
-}
-.sidebar.closed .logo-image {
-  width: 31px;
-  height: 41px;
-}
-
-.logo-title {
-  font-size: 0.6rem; /* Reducido de 0.7rem a 0.6rem */
-  font-weight: 600;
-  color: #008c6e;
-  margin: 0;
-  text-align: center;
-  line-height: 1; /* Líneas más compactas */
-  transition: all 0.3s ease;
-  white-space: normal; /* Permitir que el texto se divida en líneas */
-  max-width: 90px; /* Aumentado el ancho máximo */
-  word-wrap: break-word; /* Dividir palabras largas si es necesario */
-  hyphens: auto; /* Guiones automáticos */
-}
-
-.logo-title.hidden {
-  opacity: 0;
-  transform: translateY(-10px);
-}
-
-/* Navegación optimizada - con scroll interno */
-.navigation {
-  flex: 1;
-  padding: 1rem 0;
-  overflow-y: auto; /* Permitir scroll interno si hay muchos elementos */
-  overflow-x: hidden;
-  opacity: 1;
-  transition: all 0.3s ease;
-}
-
-/* Personalizar scrollbar del menú */
-.navigation::-webkit-scrollbar {
-  width: 4px;
-}
-
-.navigation::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.navigation::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-  border-radius: 2px;
-}
-
-.navigation::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.5);
-}
-
-/* Ocultar completamente la navegación cuando está cerrado */
-.sidebar.closed .navigation {
-  opacity: 0;
-  visibility: hidden;
-  height: 0;
-  padding: 0;
-}
-
-.navigation ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.nav-item {
-  margin: 0.01rem 1rem; /* Margen vertical*/
-  padding: 0.5rem; /* Tamaño Borde Opcion del menu*/
-  cursor: pointer;
-  display: flex;
-  flex-direction: column; /* CAMBIO: Columna en lugar de fila */
-  align-items: center;
-  gap: 0.4rem; /* Distancia Letras Icono */
-  border-radius: 8px;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  text-align: center; /* Centrar el texto */
-}
-
-/* Eliminar la regla específica para sidebar.closed .nav-item ya que estará oculto */
-
-.nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
-  transform: translateY(-2px); /* Cambio de dirección para que sea consistente con el layout vertical */
-}
-
-/* Estilo para el elemento activo en el menú */
-.nav-item.active {
-  background: rgba(255, 255, 255, 0.15);
-  border-left: 3px solid #00548c;
-}
-
-.nav-item.active .menu-icon {
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(0, 140, 74, 0.8));
-}
-
-.nav-item:active {
-  transform: translateY(-1px) scale(0.98);
-}
-
-.nav-item.logout {
-  margin-top: 0.4rem; /* Linea separadora Perfil - Cerrar Sesion */
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 0.4rem;
-}
-
-.nav-item.logout:hover {
-  background: rgba(220, 53, 69, 0.2);
-}
-
-/* Estilos específicos para los iconos del menú */
-.menu-icon {
-  width: 25px; /* Reducido de 22px a 18px */
-  height: 25px;
-  object-fit: contain;
-  transition: all 0.3s ease;
-  filter: brightness(0) invert(1);
-  margin-bottom: 0rem;
-}
-
-/* Ajustar tamaño cuando el menú está cerrado */
-.sidebar.closed .menu-icon {
-  width: 16px; /* Reducido de 20px a 16px */
-  height: 16px;
-  margin-bottom: 0;
-}
-
-/* Hover effect para los iconos */
-.nav-item:hover .menu-icon {
-  transform: scale(1.3);
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(255, 255, 255, 0.5));
-}
-
-/* Icono especial para logout */
-.nav-item.logout:hover .menu-icon {
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(220, 53, 69, 0.8));
-}
-
-/* Contenido */
-.content {
-  flex: 1;
-  padding: 2rem;
-  background: #f8f9fa;
-  margin-left: 110px;
-  transition: margin-left 0.3s ease;
-}
-.sidebar.closed + .content {
-  margin-left: 65px;
-}
-
-/* =======================
-   EXTRAS (CÓDIGO 2)
-   ======================= */
-
-.ttl {
-  color: #1a3e6a;
-  margin-bottom: 8px;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-.card {
-  background: #fff;
-  border: 1px solid var(--utem-border, #dfe5ee);
-  border-radius: 12px;
-  padding: 16px;
-  box-shadow: 0 8px 28px var(--utem-shadow, rgba(0,0,0,0.05));
-}
-
-.row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 0;
-  border-bottom: 1px dashed #eef3fb;
-}
-.row:last-child {
-  border-bottom: 0;
-}
-
-.inp {
-  border: 1px solid #dfe5ee;
-  border-radius: 10px;
-  padding: 8px 10px;
-  min-width: 220px;
-}
-
-.link {
-  color: #1976d2;
-  font-weight: 800;
-  text-decoration: none;
-}
-
-.list {
-  margin: 0;
-  padding-left: 16px;
-}
-
-/* Botón toggle mejorado */
-.menu-toggle {
-  position: absolute;
-  top: 6.6rem;
-  right:0.1rem;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 50%;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
-  z-index: 10;
-}
-
-.menu-toggle:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: scale(1.1);
+  .session-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/frontend/src/app/features/coordinacion/Perfil/perfil.component.html
+++ b/frontend/src/app/features/coordinacion/Perfil/perfil.component.html
@@ -1,112 +1,61 @@
-<div class="dashboard">
-  <!-- Sidebar -->
-  <aside class="sidebar" [ngClass]="{'open': menuOpen, 'closed': !menuOpen}">
-    <div class="logo-container" (click)="menuOpen ? null : toggleMenu()">
-      <img src="assets/utem.png" alt="Logo UTEM" class="logo-image" />
-      <h3 class="logo-title" [class.hidden]="!menuOpen">PROCESO DE TITULACIÓN</h3>
-    </div>
+<section class="perfil-page">
+  <h1 class="page-title">Perfil de Usuario</h1>
 
-    <div class="menu-toggle" (click)="toggleMenu()" [attr.aria-label]="menuOpen ? 'Cerrar menú' : 'Abrir menú'">
-      <span class="toggle-icon" [class.rotated]="!menuOpen">☰</span>
-    </div>
-
-    <nav class="navigation">
-      <ul>
-        <li class="nav-item" (click)="navigateTo('notificaciones')">
-          <img src="assets/Notificaciones.png" alt="Notificaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Notificaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('bandeja')">
-          <img src="assets/Bandeja_entrada.png" alt="Bandeja de entrada" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Bandeja de Entrada</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('inicio')">
-          <img src="assets/Inicio.png" alt="Inicio" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Inicio</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('estudiantes')">
-          <img src="assets/Estudiantes.png" alt="Estudiantes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Estudiantes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('docentes')">
-          <img src="assets/Docentes.png" alt="Docentes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Docentes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('procesos')">
-          <img src="assets/Procesos.png" alt="Procesos" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Procesos</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('evaluaciones')">
-          <img src="assets/Evaluaciones.png" alt="Evaluaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Evaluaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('reportes')">
-          <img src="assets/Reportes.png" alt="Reportes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Reportes</span>
-        </li>
-        <li class="nav-item active" (click)="navigateTo('perfil')">
-          <img src="assets/Perfil.png" alt="Perfil" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Perfil</span>
-        </li>
-        <li class="nav-item logout" (click)="logout()">
-          <img src="assets/Cerrar_Sesion.png" alt="Cerrar sesión" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Cerrar Sesión</span>
-        </li>
-      </ul>
-    </nav>
-  </aside>
-
-  <!-- Contenido principal -->
-  <main class="content">
-    <h1 class="page-title">Perfil de Usuario</h1>
-
-    <div class="grid">
-      <!-- Card Información Personal -->
-      <div class="card">
-        <h3>Información Personal</h3>
-        <div class="row"><b>Nombre:</b><span>{{ userProfile.nombre || 'Juan Pérez' }}</span></div>
-        <div class="row"><b>Correo:</b><span>{{ userProfile.correo || 'juan.perez@example.com' }}</span></div>
-        <div class="row"><b>Carrera:</b><span>{{ userProfile.carrera || 'Ingeniería Informática' }}</span></div>
-      </div>
-
-      <!-- Card Editar -->
-      <div class="card">
-        <h3>Editar Información</h3>
-        <div class="row">
-          <b>Teléfono:</b>
-          <span *ngIf="!isEditing">{{ userProfile.telefono || 'Agregar número de teléfono' }}</span>
-          <input *ngIf="isEditing" class="inp" type="tel" [(ngModel)]="editableProfile.telefono" placeholder="Agregar número de teléfono" />
-        </div>
-
-        <div class="row">
-          <b>Contraseña:</b>
-          <div *ngIf="!isEditing">
-            <span>****</span>
-            <button class="link" (click)="changePassword()">Cambiar</button>
-          </div>
-          <input *ngIf="isEditing" type="password" class="inp" [(ngModel)]="editableProfile.contrasena" placeholder="Nueva contraseña" />
-        </div>
-
-        <div class="action-row" *ngIf="!isEditing">
-          <button class="btn-edit" (click)="startEditing()">Editar Información</button>
-        </div>
-        <div class="action-row" *ngIf="isEditing">
-          <button class="btn-save" (click)="saveProfile()">Guardar</button>
-          <button class="btn-cancel" (click)="cancelEditing()">Cancelar</button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Card Historial de Sesiones -->
+  <div class="grid">
     <div class="card">
-      <h3>Historial de Sesiones</h3>
-      <ul class="list">
-        <li>Último acceso: {{ userProfile.ultimoAcceso || '25 de abril de 2024' }}</li>
-      </ul>
-      <div class="session-actions">
-        <button class="btn-session" (click)="closeSession()">Cerrar sesión</button>
-        <button class="btn-session" (click)="changePassword()">Cambiar contraseña</button>
+      <h3>Información Personal</h3>
+      <div class="row"><b>Nombre:</b><span>{{ userProfile.nombre || 'Juan Pérez' }}</span></div>
+      <div class="row"><b>Correo:</b><span>{{ userProfile.correo || 'juan.perez@example.com' }}</span></div>
+      <div class="row"><b>Carrera:</b><span>{{ userProfile.carrera || 'Ingeniería Informática' }}</span></div>
+    </div>
+
+    <div class="card">
+      <h3>Editar Información</h3>
+      <div class="row">
+        <b>Teléfono:</b>
+        <span *ngIf="!isEditing">{{ userProfile.telefono || 'Agregar número de teléfono' }}</span>
+        <input
+          *ngIf="isEditing"
+          class="inp"
+          type="tel"
+          [(ngModel)]="editableProfile.telefono"
+          placeholder="Agregar número de teléfono"
+        />
+      </div>
+
+      <div class="row">
+        <b>Contraseña:</b>
+        <div *ngIf="!isEditing">
+          <span>****</span>
+          <button class="link" type="button" (click)="changePassword()">Cambiar</button>
+        </div>
+        <input
+          *ngIf="isEditing"
+          type="password"
+          class="inp"
+          [(ngModel)]="editableProfile.contrasena"
+          placeholder="Nueva contraseña"
+        />
+      </div>
+
+      <div class="action-row" *ngIf="!isEditing">
+        <button class="btn-edit" type="button" (click)="startEditing()">Editar Información</button>
+      </div>
+      <div class="action-row" *ngIf="isEditing">
+        <button class="btn-save" type="button" (click)="saveProfile()">Guardar</button>
+        <button class="btn-cancel" type="button" (click)="cancelEditing()">Cancelar</button>
       </div>
     </div>
-  </main>
-</div>
+  </div>
+
+  <div class="card">
+    <h3>Historial de Sesiones</h3>
+    <ul class="list">
+      <li>Último acceso: {{ userProfile.ultimoAcceso || '25 de abril de 2024' }}</li>
+    </ul>
+    <div class="session-actions">
+      <button class="btn-session" type="button" (click)="closeSession()">Cerrar sesión</button>
+      <button class="btn-session" type="button" (click)="changePassword()">Cambiar contraseña</button>
+    </div>
+  </div>
+</section>

--- a/frontend/src/app/features/coordinacion/Perfil/perfil.component.ts
+++ b/frontend/src/app/features/coordinacion/Perfil/perfil.component.ts
@@ -21,7 +21,6 @@ interface UserProfile {
   styleUrls: ['./perfil.component.css'],
 })
 export class CoordinacionPerfilComponent implements OnInit {
-  menuOpen = true;
   isEditing = false;
 
   userProfile: UserProfile = {
@@ -95,16 +94,8 @@ export class CoordinacionPerfilComponent implements OnInit {
     this.isEditing = false;
   }
 
-  toggleMenu(): void {
-    this.menuOpen = !this.menuOpen;
-  }
-
-  navigateTo(section: string): void {
-    console.log(`Navegando a: ${section}`);
-  }
-
-  logout(): void {
-     if (!confirm('¿Estás seguro de que quieres cerrar sesión?')) {
+  closeSession(): void {
+    if (!confirm('¿Estás seguro de que quieres cerrar sesión?')) {
       return;
     }
 
@@ -112,10 +103,6 @@ export class CoordinacionPerfilComponent implements OnInit {
       next: () => this.router.navigateByUrl('/auth/login'),
       error: () => this.router.navigateByUrl('/auth/login'),
     });
-  }
-
-  closeSession(): void {
-    this.logout();
   }
 
   private showSuccessMessage(message: string): void {

--- a/frontend/src/app/features/coordinacion/estudiantes/estudiantes.component.css
+++ b/frontend/src/app/features/coordinacion/estudiantes/estudiantes.component.css
@@ -1,216 +1,18 @@
-/* ESTILOS PARA FRONTEND DE ESTUDIANTES */
-
-/* Incluir los estilos base del sidebar que ya tienes */
-/* Dashboard principal */
-.dashboard {
-  display: flex;
-  min-height: 100vh;
+:host {
+  display: block;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f5f5f5;
 }
 
-/* Todos los estilos del sidebar del archivo original */
-.sidebar {
-  width: 110px;
-  background: linear-gradient(180deg, #301e30 0%, #2a1a2a 100%);
-  color: white;
-  padding: 0;
+.students-page {
   display: flex;
   flex-direction: column;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100vh;
-  z-index: 1000;
-  overflow: hidden;
+  gap: 2rem;
 }
 
-.sidebar.closed {
-  width: 65px;
-}
-
-.logo-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0.5rem 1.5rem 0.2rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  min-height: 100px;
-  justify-content: center;
-  position: relative;
-}
-
-.logo-image {
-  width: 52px;
-  height: 65px;
-  object-fit: contain;
-  margin-bottom: 0.3rem;
-  transition: all 0.3s ease;
-}
-
-.sidebar.closed .logo-image {
-  width: 31px;
-  height: 41px;
-}
-
-.logo-title {
-  font-size: 0.6rem;
-  font-weight: 600;
-  color: #008c6e;
-  margin: 0;
-  text-align: center;
-  line-height: 1;
-  transition: all 0.3s ease;
-  white-space: normal;
-  max-width: 90px;
-  word-wrap: break-word;
-  hyphens: auto;
-}
-
-.logo-title.hidden {
-  opacity: 0;
-  transform: translateY(-10px);
-}
-
-.menu-toggle {
-  position: absolute;
-  top: 6.6rem;
-  right: 0.1rem;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 50%;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
-  z-index: 10;
-}
-
-.menu-toggle:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: scale(1.1);
-}
-
-.toggle-icon {
-  font-size: 1.3rem;
-  transition: transform 0.3s ease;
-  color: white;
-}
-
-.navigation {
-  flex: 1;
-  padding: 1rem 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  opacity: 1;
-  transition: all 0.3s ease;
-}
-
-.sidebar.closed .navigation {
-  opacity: 0;
-  visibility: hidden;
-  height: 0;
-  padding: 0;
-}
-
-.navigation ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.nav-item {
-  margin: 0.01rem 1rem;
-  padding: 0.5rem;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.4rem;
-  border-radius: 8px;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  text-align: center;
-}
-
-.nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
-  transform: translateY(-2px);
-}
-
-.nav-item.active {
-  background: rgba(0, 140, 110, 0.3);
-  border-left: 3px solid #008c6e;
-}
-
-.nav-item.logout {
-  margin-top: 0.4rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 0.4rem;
-}
-
-.nav-item.logout:hover {
-  background: rgba(220, 53, 69, 0.2);
-}
-
-.menu-icon {
-  width: 25px;
-  height: 25px;
-  object-fit: contain;
-  transition: all 0.3s ease;
-  filter: brightness(0) invert(1);
-  margin-bottom: 0rem;
-}
-
-.nav-item:hover .menu-icon {
-  transform: scale(1.3);
-  filter: brightness(0) invert(1) drop-shadow(0 0 3px rgba(255, 255, 255, 0.5));
-}
-
-.label {
-  font-size: 0.55rem;
-  font-weight: 500;
-  transition: all 0.3s ease;
-  white-space: nowrap;
-  text-align: center;
-  line-height: 1;
-  max-width: 90px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.label.hidden {
-  opacity: 0;
-  transform: translateY(-8px);
-}
-
-/* Contenido principal - específico para estudiantes */
-.content {
-  flex: 1;
-  padding: 2rem;
-  background: #f8f9fa;
-  overflow-y: auto;
-  margin-left: 110px;
-  transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  min-height: 100vh;
-}
-
-.sidebar.closed + .content {
-  margin-left: 65px;
-}
-
-/* Header de página */
 .page-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
   padding-bottom: 1rem;
   border-bottom: 2px solid #e9ecef;
 }
@@ -228,7 +30,6 @@
   align-items: center;
 }
 
-/* Botones generales */
 .btn {
   padding: 0.75rem 1.5rem;
   border: none;
@@ -251,7 +52,6 @@
 
 .btn-primary {
   background: linear-gradient(135deg, #008c4a, #006d37);
-  color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -262,7 +62,6 @@
 
 .btn-secondary {
   background: linear-gradient(135deg, #6c757d, #5a6268);
-  color: white;
 }
 
 .btn-secondary:hover:not(:disabled) {
@@ -290,12 +89,10 @@
   font-size: 1rem;
 }
 
-/* Sección de filtros */
 .filters-section {
   background: white;
   padding: 1.5rem;
   border-radius: 12px;
-  margin-bottom: 2rem;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
@@ -354,7 +151,6 @@
   box-shadow: 0 0 0 3px rgba(0, 140, 74, 0.1);
 }
 
-/* Loading */
 .loading-container {
   display: flex;
   flex-direction: column;
@@ -375,8 +171,12 @@
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .loading-text {
@@ -385,7 +185,6 @@
   margin: 0;
 }
 
-/* Contenedor de tabla */
 .table-container {
   background: white;
   border-radius: 12px;
@@ -414,7 +213,6 @@
   gap: 0.5rem;
 }
 
-/* Tabla de datos */
 .table-wrapper {
   overflow-x: auto;
 }
@@ -435,13 +233,12 @@
   white-space: nowrap;
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 1;
 }
 
 .data-table th.sortable {
   cursor: pointer;
   user-select: none;
-  position: relative;
 }
 
 .data-table th.sortable:hover {
@@ -479,7 +276,6 @@
   background-color: rgba(0, 140, 74, 0.05);
 }
 
-/* Celdas específicas */
 .student-name .name-container {
   display: flex;
   align-items: center;
@@ -497,7 +293,6 @@
   justify-content: center;
   font-weight: 600;
   font-size: 0.9rem;
-  flex-shrink: 0;
 }
 
 .name-info {
@@ -517,171 +312,120 @@
   color: #6c757d;
 }
 
-.rut-cell {
-  font-family: 'Courier New', monospace;
-  font-weight: 600;
-}
-
-.career-name {
-  color: #495057;
-  font-weight: 500;
-}
-
 .email-link {
-  color: #008c4a;
+  color: #1976d2;
   text-decoration: none;
-  transition: all 0.3s ease;
 }
 
 .email-link:hover {
-  color: #006d37;
   text-decoration: underline;
 }
 
-/* Estados */
 .status-badge {
-  padding: 0.4rem 0.8rem;
-  border-radius: 20px;
-  font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: white;
 }
 
 .status-activo {
-  background: linear-gradient(135deg, #28a745, #20c997);
+  background: rgba(0, 140, 74, 0.1);
+  color: #008c4a;
 }
 
 .status-en-proceso {
-  background: linear-gradient(135deg, #ffc107, #fd7e14);
+  background: rgba(255, 193, 7, 0.1);
+  color: #d48b00;
 }
 
 .status-graduado {
-  background: linear-gradient(135deg, #007bff, #6f42c1);
+  background: rgba(25, 118, 210, 0.1);
+  color: #1976d2;
 }
 
 .status-retirado {
-  background: linear-gradient(135deg, #dc3545, #e83e8c);
+  background: rgba(220, 53, 69, 0.1);
+  color: #dc3545;
 }
 
-.date-cell {
-  font-family: 'Courier New', monospace;
-  color: #6c757d;
-}
-
-/* Acciones */
-.actions-column {
-  width: 150px;
-}
-
-.action-buttons {
+.actions-cell .action-buttons {
   display: flex;
   gap: 0.5rem;
-  justify-content: center;
 }
 
 .btn-action {
-  width: 35px;
-  height: 35px;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
   border: none;
-  border-radius: 6px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
-  transition: all 0.3s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .btn-view {
   background: #e3f2fd;
-  color: #1976d2;
-}
-
-.btn-view:hover {
-  background: #bbdefb;
-  transform: translateY(-2px);
 }
 
 .btn-edit {
-  background: #fff3e0;
-  color: #f57c00;
-}
-
-.btn-edit:hover {
-  background: #ffe0b2;
-  transform: translateY(-2px);
+  background: #fff3cd;
 }
 
 .btn-delete {
-  background: #ffebee;
-  color: #d32f2f;
+  background: #fdecea;
 }
 
-.btn-delete:hover {
-  background: #ffcdd2;
+.btn-action:hover {
   transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
-/* No data */
 .no-data-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 3rem 2rem;
   text-align: center;
-  padding: 4rem 2rem;
-  color: #6c757d;
 }
 
 .no-data-icon {
-  font-size: 4rem;
-  margin-bottom: 1rem;
-  opacity: 0.5;
+  font-size: 2rem;
 }
 
-.no-data-container h3 {
-  margin: 0 0 1rem 0;
-  color: #495057;
-}
-
-.no-data-container p {
-  margin: 0 0 2rem 0;
-  font-size: 1rem;
-}
-
-/* Paginación */
 .pagination-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem;
+  padding: 1rem 1.5rem;
   border-top: 1px solid #e9ecef;
-  background: #f8f9fa;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .pagination-info {
   color: #6c757d;
-  font-size: 0.9rem;
 }
 
 .pagination-controls {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-.pagination-btn {
-  padding: 0.5rem 1rem;
+.pagination-btn,
+.page-number {
+  padding: 0.5rem 0.9rem;
+  border-radius: 6px;
   border: 1px solid #dee2e6;
   background: white;
-  color: #495057;
-  border-radius: 6px;
   cursor: pointer;
-  transition: all 0.3s ease;
-  font-size: 0.9rem;
-}
-
-.pagination-btn:hover:not(:disabled) {
-  background: #e9ecef;
-  border-color: #adb5bd;
+  transition: all 0.2s ease;
 }
 
 .pagination-btn:disabled {
@@ -689,72 +433,34 @@
   cursor: not-allowed;
 }
 
-.page-numbers {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.page-number {
-  width: 40px;
-  height: 40px;
-  border: 1px solid #dee2e6;
-  background: white;
-  color: #495057;
-  border-radius: 6px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.9rem;
-  transition: all 0.3s ease;
-}
-
+.page-number.active,
 .page-number:hover {
-  background: #e9ecef;
-  border-color: #adb5bd;
-}
-
-.page-number.active {
   background: #008c4a;
-  color: white;
   border-color: #008c4a;
+  color: white;
 }
 
-/* Modal */
 .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 2000;
-  backdrop-filter: blur(2px);
+  padding: 1.5rem;
+  z-index: 1000;
 }
 
 .modal-container {
   background: white;
-  border-radius: 12px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
-  width: 90vw;
-  max-width: 600px;
+  border-radius: 16px;
+  width: min(720px, 100%);
   max-height: 90vh;
   overflow-y: auto;
-  animation: modalSlideIn 0.3s ease;
-}
-
-@keyframes modalSlideIn {
-  from {
-    opacity: 0;
-    transform: scale(0.9) translateY(-20px);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.15);
 }
 
 .modal-header {
@@ -767,62 +473,43 @@
 
 .modal-header h2 {
   margin: 0;
-  color: #333;
-  font-size: 1.5rem;
-  font-weight: 600;
+  font-size: 1.4rem;
+  color: #1a3e6a;
 }
 
 .modal-close {
-  width: 30px;
-  height: 30px;
   border: none;
-  background: #f8f9fa;
-  border-radius: 50%;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background: transparent;
   font-size: 1.2rem;
-  color: #6c757d;
-  transition: all 0.3s ease;
+  cursor: pointer;
 }
 
-.modal-close:hover {
-  background: #e9ecef;
-  color: #495057;
-}
-
-/* Formulario */
 .modal-form {
   padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .form-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
-  margin-bottom: 1rem;
 }
 
 .form-group {
-  flex: 1;
   display: flex;
   flex-direction: column;
-}
-
-.form-group label {
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: #333;
-  font-size: 0.9rem;
+  gap: 0.5rem;
 }
 
 .form-input {
-  padding: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
   border: 1px solid #dee2e6;
   border-radius: 8px;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   transition: all 0.3s ease;
-  background: white;
 }
 
 .form-input:focus {
@@ -831,115 +518,27 @@
   box-shadow: 0 0 0 3px rgba(0, 140, 74, 0.1);
 }
 
-.form-input:invalid {
-  border-color: #dc3545;
-}
-
 .modal-actions {
   display: flex;
   justify-content: flex-end;
   gap: 1rem;
-  margin-top: 2rem;
-  padding-top: 1rem;
-  border-top: 1px solid #e9ecef;
 }
 
-/* Responsive */
 @media (max-width: 768px) {
-  .sidebar {
-    transform: translateX(-100%);
-  }
-  
-  .sidebar.open {
-    transform: translateX(0);
-  }
-  
-  .content {
-    margin-left: 0 !important;
-    padding: 1rem;
-  }
-  
   .page-header {
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
   }
-  
+
   .header-actions {
-    flex-direction: column;
     width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
-  
-  .filters-section {
-    padding: 1rem;
-  }
-  
-  .filter-controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  
-  .filter-select {
-    min-width: auto;
-  }
-  
-  .table-wrapper {
-    font-size: 0.8rem;
-  }
-  
-  .data-table th,
-  .data-table td {
-    padding: 0.5rem;
-  }
-  
-  .name-container {
-    flex-direction: column;
-    text-align: center;
-    gap: 0.5rem;
-  }
-  
-  .action-buttons {
-    flex-direction: column;
-  }
-  
+
   .pagination-container {
     flex-direction: column;
-    gap: 1rem;
-    text-align: center;
-  }
-  
-  .modal-container {
-    width: 95vw;
-    margin: 1rem;
-  }
-  
-  .form-row {
-    flex-direction: column;
-    gap: 0;
-  }
-  
-  .modal-actions {
-    flex-direction: column;
-  }
-}
-
-@media (max-width: 480px) {
-  .btn {
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-  }
-  
-  .cards {
-    grid-template-columns: 1fr;
-  }
-  
-  .table-wrapper {
-    font-size: 0.7rem;
-  }
-  
-  .btn-action {
-    width: 30px;
-    height: 30px;
-    font-size: 0.8rem;
+    align-items: flex-start;
   }
 }

--- a/frontend/src/app/features/coordinacion/estudiantes/estudiantes.component.html
+++ b/frontend/src/app/features/coordinacion/estudiantes/estudiantes.component.html
@@ -1,391 +1,306 @@
-<!-- FRONTEND DE ESTUDIANTES -->
-<div class="dashboard">
-  <aside class="sidebar" [ngClass]="{'open': menuOpen, 'closed': !menuOpen}">
-    <!-- Logo siempre visible en la parte superior - clickeable para abrir menú -->
-    <div class="logo-container" (click)="menuOpen ? null : toggleMenu()">
-      <img src="assets/utem.png" alt="Logo UTEM" class="logo-image" />
-      <h3 class="logo-title" [class.hidden]="!menuOpen">PROCESO DE TITULACIÓN</h3>
+<section class="students-page">
+  <div class="page-header">
+    <h1 class="title">Gestión de Estudiantes</h1>
+    <div class="header-actions">
+      <button class="btn btn-primary" type="button" (click)="openAddModal()">
+        <span class="btn-icon">➕</span>
+        Agregar Estudiante
+      </button>
+      <button class="btn btn-secondary" type="button" (click)="exportData()" [disabled]="isLoading">
+        <span class="btn-icon">📊</span>
+        Exportar Excel
+      </button>
     </div>
-    
-    <!-- Botón toggle optimizado -->
-    <div class="menu-toggle" (click)="toggleMenu()" [attr.aria-label]="menuOpen ? 'Cerrar menú' : 'Abrir menú'">
-      <span class="toggle-icon" [class.rotated]="!menuOpen">☰</span>
-    </div>
-    
-    <!-- Navegación mejorada -->
-    <nav class="navigation">
-      <ul>
-        <li class="nav-item" (click)="navigateTo('notificaciones')">
-          <img src="assets/Notificaciones.png" alt="Notificaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Notificaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('bandeja')">
-          <img src="assets/Bandeja_entrada.png" alt="Bandeja de entrada" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Bandeja de Entrada</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('inicio')">
-          <img src="assets/Inicio.png" alt="Inicio" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Inicio</span>
-        </li>
-        <li class="nav-item active" (click)="navigateTo('estudiantes')">
-          <img src="assets/Estudiantes.png" alt="Estudiantes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Estudiantes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('docentes')">
-          <img src="assets/Docentes.png" alt="Docentes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Docentes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('procesos')">
-          <img src="assets/Procesos.png" alt="Procesos" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Procesos</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('evaluaciones')">
-          <img src="assets/Evaluaciones.png" alt="Evaluaciones" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Evaluaciones</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('reportes')">
-          <img src="assets/Reportes.png" alt="Reportes" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Reportes</span>
-        </li>
-        <li class="nav-item" (click)="navigateTo('perfil')">
-          <img src="assets/Perfil.png" alt="Perfil" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Perfil</span>
-        </li>
-        <li class="nav-item logout" (click)="logout()">
-          <img src="assets/Cerrar_Sesion.png" alt="Cerrar sesión" class="menu-icon" />
-          <span class="label" [class.hidden]="!menuOpen">Cerrar Sesión</span>
-        </li>
-      </ul>
-    </nav>
-  </aside>
+  </div>
 
-  <main class="content">
-    <div class="page-header">
-      <h1 class="title">Gestión de Estudiantes</h1>
-      <div class="header-actions">
-        <button class="btn btn-primary" (click)="openAddModal()">
-          <span class="btn-icon">➕</span>
-          Agregar Estudiante
-        </button>
-        <button class="btn btn-secondary" (click)="exportData()" [disabled]="isLoading">
-          <span class="btn-icon">📊</span>
-          Exportar Excel
+  <div class="filters-section">
+    <div class="search-container">
+      <input
+        type="text"
+        placeholder="Buscar por nombre, RUT o carrera..."
+        class="search-input"
+        [(ngModel)]="searchTerm"
+        (input)="onSearch()"
+      />
+      <span class="search-icon">🔍</span>
+    </div>
+
+    <div class="filter-controls">
+      <select class="filter-select" [(ngModel)]="selectedCarrera" (change)="onFilterChange()">
+        <option value="">Todas las carreras</option>
+        <option *ngFor="let carrera of carreras" [value]="carrera.id">{{ carrera.nombre }}</option>
+      </select>
+
+      <select class="filter-select" [(ngModel)]="selectedEstado" (change)="onFilterChange()">
+        <option value="">Todos los estados</option>
+        <option value="activo">Activo</option>
+        <option value="en-proceso">En proceso</option>
+        <option value="graduado">Graduado</option>
+        <option value="retirado">Retirado</option>
+      </select>
+
+      <button class="btn btn-ghost" type="button" (click)="clearFilters()">
+        <span class="btn-icon">🗑️</span>
+        Limpiar
+      </button>
+    </div>
+  </div>
+
+  <div *ngIf="isLoading" class="loading-container">
+    <div class="loading-spinner"></div>
+    <p class="loading-text">Cargando estudiantes...</p>
+  </div>
+
+  <div class="table-container" *ngIf="!isLoading">
+    <div class="table-header">
+      <h3>Lista de Estudiantes ({{ filteredEstudiantes.length }})</h3>
+      <div class="table-actions">
+        <button class="btn btn-ghost btn-sm" type="button" (click)="refreshData()">
+          <span class="btn-icon">🔄</span>
+          Actualizar
         </button>
       </div>
     </div>
 
-    <!-- Filtros y búsqueda -->
-    <div class="filters-section">
-      <div class="search-container">
-        <input 
-          type="text" 
-          placeholder="Buscar por nombre, RUT o carrera..." 
-          class="search-input"
-          [(ngModel)]="searchTerm"
-          (input)="onSearch()"
-        />
-        <span class="search-icon">🔍</span>
-      </div>
-      
-      <div class="filter-controls">
-        <select class="filter-select" [(ngModel)]="selectedCarrera" (change)="onFilterChange()">
-          <option value="">Todas las carreras</option>
-          <option *ngFor="let carrera of carreras" [value]="carrera.id">{{ carrera.nombre }}</option>
-        </select>
-        
-        <select class="filter-select" [(ngModel)]="selectedEstado" (change)="onFilterChange()">
-          <option value="">Todos los estados</option>
-          <option value="activo">Activo</option>
-          <option value="en-proceso">En proceso</option>
-          <option value="graduado">Graduado</option>
-          <option value="retirado">Retirado</option>
-        </select>
-        
-        <button class="btn btn-ghost" (click)="clearFilters()">
-          <span class="btn-icon">🗑️</span>
-          Limpiar
-        </button>
-      </div>
-    </div>
-
-    <!-- Loading indicator -->
-    <div *ngIf="isLoading" class="loading-container">
-      <div class="loading-spinner"></div>
-      <p class="loading-text">Cargando estudiantes...</p>
-    </div>
-
-    <!-- Tabla de estudiantes -->
-    <div class="table-container" *ngIf="!isLoading">
-      <div class="table-header">
-        <h3>Lista de Estudiantes ({{ filteredEstudiantes.length }})</h3>
-        <div class="table-actions">
-          <button class="btn btn-ghost btn-sm" (click)="refreshData()">
-            <span class="btn-icon">🔄</span>
-            Actualizar
-          </button>
-        </div>
-      </div>
-      
-      <div class="table-wrapper">
-        <table class="data-table" *ngIf="filteredEstudiantes.length > 0; else noDataTemplate">
-          <thead>
-            <tr>
-              <th class="sortable" (click)="sortBy('nombre')">
-                Nombre Completo
-                <span class="sort-icon" [class.active]="sortField === 'nombre'">↕️</span>
-              </th>
-              <th class="sortable" (click)="sortBy('rut')">
-                RUT
-                <span class="sort-icon" [class.active]="sortField === 'rut'">↕️</span>
-              </th>
-              <th class="sortable" (click)="sortBy('carrera')">
-                Carrera
-                <span class="sort-icon" [class.active]="sortField === 'carrera'">↕️</span>
-              </th>
-              <th>Email</th>
-              <th class="sortable" (click)="sortBy('estado')">
-                Estado
-                <span class="sort-icon" [class.active]="sortField === 'estado'">↕️</span>
-              </th>
-              <th>Fecha Ingreso</th>
-              <th class="actions-column">Acciones</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr *ngFor="let estudiante of paginatedEstudiantes; trackBy: trackByEstudianteId" 
-                class="table-row" 
-                [class.selected]="estudiante.id && selectedEstudiantes.includes(estudiante.id)">
-              
-              <td class="student-name">
-                <div class="name-container">
-                  <div class="avatar">{{ getInitials(estudiante.nombre) }}</div>
-                  <div class="name-info">
-                    <span class="full-name">{{ estudiante.nombre }} {{ estudiante.apellido }}</span>
-                    <span class="student-id">ID: {{ estudiante.id }}</span>
-                  </div>
+    <div class="table-wrapper">
+      <table class="data-table" *ngIf="filteredEstudiantes.length > 0; else noDataTemplate">
+        <thead>
+          <tr>
+            <th class="sortable" (click)="sortBy('nombre')">
+              Nombre Completo
+              <span class="sort-icon" [class.active]="sortField === 'nombre'">↕️</span>
+            </th>
+            <th class="sortable" (click)="sortBy('rut')">
+              RUT
+              <span class="sort-icon" [class.active]="sortField === 'rut'">↕️</span>
+            </th>
+            <th class="sortable" (click)="sortBy('carrera')">
+              Carrera
+              <span class="sort-icon" [class.active]="sortField === 'carrera'">↕️</span>
+            </th>
+            <th>Email</th>
+            <th class="sortable" (click)="sortBy('estado')">
+              Estado
+              <span class="sort-icon" [class.active]="sortField === 'estado'">↕️</span>
+            </th>
+            <th>Fecha Ingreso</th>
+            <th class="actions-column">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            *ngFor="let estudiante of paginatedEstudiantes; trackBy: trackByEstudianteId"
+            class="table-row"
+            [class.selected]="estudiante.id && selectedEstudiantes.includes(estudiante.id)"
+          >
+            <td class="student-name">
+              <div class="name-container">
+                <div class="avatar">{{ getInitials(estudiante.nombre) }}</div>
+                <div class="name-info">
+                  <span class="full-name">{{ estudiante.nombre }} {{ estudiante.apellido }}</span>
+                  <span class="student-id">ID: {{ estudiante.id }}</span>
                 </div>
-              </td>
-              
-              <td class="rut-cell">{{ estudiante.rut }}</td>
-              
-              <td class="career-cell">
-                <span class="career-name">{{ estudiante.carrera }}</span>
-              </td>
-              
-              <td class="email-cell">
-                <a [href]="'mailto:' + estudiante.email" class="email-link">{{ estudiante.email }}</a>
-              </td>
-              
-              <td class="status-cell">
-                <span class="status-badge" [class]="'status-' + estudiante.estado">
-                  {{ getEstadoText(estudiante.estado) }}
-                </span>
-              </td>
-              
-              <td class="date-cell">{{ estudiante.fechaIngreso | date:'dd/MM/yyyy' }}</td>
-              
-              <td class="actions-cell">
-                <div class="action-buttons">
-                  <button class="btn-action btn-view" 
-                          (click)="viewEstudiante(estudiante)"
-                          title="Ver detalles">
-                    👁️
-                  </button>
-                  <button class="btn-action btn-edit" 
-                          (click)="editEstudiante(estudiante)"
-                          title="Editar">
-                    ✏️
-                  </button>
-                  <button class="btn-action btn-delete" 
-                          (click)="deleteEstudiante(estudiante)"
-                          title="Eliminar">
-                    🗑️
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              </div>
+            </td>
+            <td class="rut-cell">{{ estudiante.rut }}</td>
+            <td class="career-cell">
+              <span class="career-name">{{ estudiante.carrera }}</span>
+            </td>
+            <td class="email-cell">
+              <a [href]="'mailto:' + estudiante.email" class="email-link">{{ estudiante.email }}</a>
+            </td>
+            <td class="status-cell">
+              <span class="status-badge" [class]="'status-' + estudiante.estado">
+                {{ getEstadoText(estudiante.estado) }}
+              </span>
+            </td>
+            <td class="date-cell">{{ estudiante.fechaIngreso | date: 'dd/MM/yyyy' }}</td>
+            <td class="actions-cell">
+              <div class="action-buttons">
+                <button class="btn-action btn-view" type="button" (click)="viewEstudiante(estudiante)" title="Ver detalles">
+                  👁️
+                </button>
+                <button class="btn-action btn-edit" type="button" (click)="editEstudiante(estudiante)" title="Editar">
+                  ✏️
+                </button>
+                <button class="btn-action btn-delete" type="button" (click)="deleteEstudiante(estudiante)" title="Eliminar">
+                  🗑️
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-        <!-- Template cuando no hay datos -->
-        <ng-template #noDataTemplate>
-          <div class="no-data-container">
-            <div class="no-data-icon">👥</div>
-            <h3>No se encontraron estudiantes</h3>
-            <p>No hay estudiantes que coincidan con los filtros seleccionados.</p>
-            <button class="btn btn-primary" (click)="openAddModal()">
-              Agregar primer estudiante
-            </button>
-          </div>
-        </ng-template>
-      </div>
-
-      <!-- Paginación -->
-      <div class="pagination-container" *ngIf="filteredEstudiantes.length > pageSize">
-        <div class="pagination-info">
-          Mostrando {{ getStartIndex() }} - {{ getEndIndex() }} de {{ filteredEstudiantes.length }} estudiantes
-        </div>
-        
-        <div class="pagination-controls">
-          <button class="pagination-btn" 
-                  [disabled]="currentPage === 1" 
-                  (click)="goToPage(currentPage - 1)">
-            ← Anterior
-          </button>
-          
-          <span class="page-numbers">
-            <button *ngFor="let page of getPageNumbers()" 
-                    class="page-number"
-                    [class.active]="page === currentPage"
-                    (click)="goToPage(page)">
-              {{ page }}
-            </button>
-          </span>
-          
-          <button class="pagination-btn" 
-                  [disabled]="currentPage === totalPages" 
-                  (click)="goToPage(currentPage + 1)">
-            Siguiente →
+      <ng-template #noDataTemplate>
+        <div class="no-data-container">
+          <div class="no-data-icon">👥</div>
+          <h3>No se encontraron estudiantes</h3>
+          <p>No hay estudiantes que coincidan con los filtros seleccionados.</p>
+          <button class="btn btn-primary" type="button" (click)="openAddModal()">
+            Agregar primer estudiante
           </button>
         </div>
-      </div>
+      </ng-template>
     </div>
 
-    <!-- Modal para agregar/editar estudiante -->
-    <div class="modal-overlay" *ngIf="showModal" (click)="closeModal()">
-      <div class="modal-container" (click)="$event.stopPropagation()">
-        <div class="modal-header">
-          <h2>{{ isEditing ? 'Editar' : 'Agregar' }} Estudiante</h2>
-          <button class="modal-close" (click)="closeModal()">✕</button>
-        </div>
-        
-        <form class="modal-form" (ngSubmit)="saveEstudiante()" #estudianteForm="ngForm">
-          <div class="form-row">
-            <div class="form-group">
-              <label for="nombre">Nombre *</label>
-              <input 
-                type="text" 
-                id="nombre" 
-                name="nombre"
-                [(ngModel)]="currentEstudiante.nombre"
-                required
-                class="form-input"
-                placeholder="Ingrese el nombre"
-              />
-            </div>
-            
-            <div class="form-group">
-              <label for="apellido">Apellido *</label>
-              <input 
-                type="text" 
-                id="apellido" 
-                name="apellido"
-                [(ngModel)]="currentEstudiante.apellido"
-                required
-                class="form-input"
-                placeholder="Ingrese el apellido"
-              />
-            </div>
-          </div>
-          
-          <div class="form-row">
-            <div class="form-group">
-              <label for="rut">RUT *</label>
-              <input 
-                type="text" 
-                id="rut" 
-                name="rut"
-                [(ngModel)]="currentEstudiante.rut"
-                required
-                class="form-input"
-                placeholder="12.345.678-9"
-              />
-            </div>
-            
-            <div class="form-group">
-              <label for="email">Email *</label>
-              <input 
-                type="email" 
-                id="email" 
-                name="email"
-                [(ngModel)]="currentEstudiante.email"
-                required
-                class="form-input"
-                placeholder="estudiante@ejemplo.com"
-              />
-            </div>
-          </div>
-          
-          <div class="form-row">
-            <div class="form-group">
-              <label for="carrera">Carrera *</label>
-              <select 
-                id="carrera" 
-                name="carrera"
-                [(ngModel)]="currentEstudiante.carreraId"
-                required
-                class="form-input"
-              >
-                <option value="">Seleccione una carrera</option>
-                <option *ngFor="let carrera of carreras" [value]="carrera.id">
-                  {{ carrera.nombre }}
-                </option>
-              </select>
-            </div>
-            
-            <div class="form-group">
-              <label for="estado">Estado</label>
-              <select 
-                id="estado" 
-                name="estado"
-                [(ngModel)]="currentEstudiante.estado"
-                class="form-input"
-              >
-                <option value="activo">Activo</option>
-                <option value="en-proceso">En proceso</option>
-                <option value="graduado">Graduado</option>
-                <option value="retirado">Retirado</option>
-              </select>
-            </div>
-          </div>
-          
-          <div class="form-row">
-            <div class="form-group">
-              <label for="telefono">Teléfono</label>
-              <input 
-                type="tel" 
-                id="telefono" 
-                name="telefono"
-                [(ngModel)]="currentEstudiante.telefono"
-                class="form-input"
-                placeholder="+56 9 1234 5678"
-              />
-            </div>
-            
-            <div class="form-group">
-              <label for="fechaIngreso">Fecha de Ingreso</label>
-              <input 
-                type="date" 
-                id="fechaIngreso" 
-                name="fechaIngreso"
-                [(ngModel)]="currentEstudiante.fechaIngreso"
-                class="form-input"
-              />
-            </div>
-          </div>
-          
-          <div class="modal-actions">
-            <button type="button" class="btn btn-secondary" (click)="closeModal()">
-              Cancelar
-            </button>
-            <button type="submit" 
-                    class="btn btn-primary" 
-                    [disabled]="!estudianteForm.form.valid || isSaving">
-              {{ isSaving ? 'Guardando...' : (isEditing ? 'Actualizar' : 'Agregar') }}
-            </button>
-          </div>
-        </form>
+    <div class="pagination-container" *ngIf="filteredEstudiantes.length > pageSize">
+      <div class="pagination-info">
+        Mostrando {{ getStartIndex() }} - {{ getEndIndex() }} de {{ filteredEstudiantes.length }} estudiantes
+      </div>
+      <div class="pagination-controls">
+        <button class="pagination-btn" type="button" [disabled]="currentPage === 1" (click)="goToPage(currentPage - 1)">
+          ← Anterior
+        </button>
+        <span class="page-numbers">
+          <button
+            *ngFor="let page of getPageNumbers()"
+            class="page-number"
+            [class.active]="page === currentPage"
+            type="button"
+            (click)="goToPage(page)"
+          >
+            {{ page }}
+          </button>
+        </span>
+        <button
+          class="pagination-btn"
+          type="button"
+          [disabled]="currentPage === totalPages"
+          (click)="goToPage(currentPage + 1)"
+        >
+          Siguiente →
+        </button>
       </div>
     </div>
-  </main>
-</div>
+  </div>
+
+  <div class="modal-overlay" *ngIf="showModal" (click)="closeModal()">
+    <div class="modal-container" (click)="$event.stopPropagation()">
+      <div class="modal-header">
+        <h2>{{ isEditing ? 'Editar' : 'Agregar' }} Estudiante</h2>
+        <button class="modal-close" type="button" (click)="closeModal()">✕</button>
+      </div>
+
+      <form class="modal-form" (ngSubmit)="saveEstudiante()" #estudianteForm="ngForm">
+        <div class="form-row">
+          <div class="form-group">
+            <label for="nombre">Nombre *</label>
+            <input
+              type="text"
+              id="nombre"
+              name="nombre"
+              [(ngModel)]="currentEstudiante.nombre"
+              required
+              class="form-input"
+              placeholder="Ingrese el nombre"
+            />
+          </div>
+          <div class="form-group">
+            <label for="apellido">Apellido *</label>
+            <input
+              type="text"
+              id="apellido"
+              name="apellido"
+              [(ngModel)]="currentEstudiante.apellido"
+              required
+              class="form-input"
+              placeholder="Ingrese el apellido"
+            />
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label for="rut">RUT *</label>
+            <input
+              type="text"
+              id="rut"
+              name="rut"
+              [(ngModel)]="currentEstudiante.rut"
+              required
+              class="form-input"
+              placeholder="12.345.678-9"
+            />
+          </div>
+          <div class="form-group">
+            <label for="email">Email *</label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              [(ngModel)]="currentEstudiante.email"
+              required
+              class="form-input"
+              placeholder="estudiante@ejemplo.com"
+            />
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label for="carrera">Carrera *</label>
+            <select
+              id="carrera"
+              name="carrera"
+              [(ngModel)]="currentEstudiante.carreraId"
+              required
+              class="form-input"
+            >
+              <option value="">Seleccione una carrera</option>
+              <option *ngFor="let carrera of carreras" [value]="carrera.id">
+                {{ carrera.nombre }}
+              </option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="estado">Estado</label>
+            <select id="estado" name="estado" [(ngModel)]="currentEstudiante.estado" class="form-input">
+              <option value="activo">Activo</option>
+              <option value="en-proceso">En proceso</option>
+              <option value="graduado">Graduado</option>
+              <option value="retirado">Retirado</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label for="telefono">Teléfono</label>
+            <input
+              type="tel"
+              id="telefono"
+              name="telefono"
+              [(ngModel)]="currentEstudiante.telefono"
+              class="form-input"
+              placeholder="+56 9 1234 5678"
+            />
+          </div>
+          <div class="form-group">
+            <label for="fechaIngreso">Fecha de Ingreso</label>
+            <input
+              type="date"
+              id="fechaIngreso"
+              name="fechaIngreso"
+              [(ngModel)]="currentEstudiante.fechaIngreso"
+              class="form-input"
+            />
+          </div>
+        </div>
+
+        <div class="modal-actions">
+          <button type="button" class="btn btn-secondary" (click)="closeModal()">
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            class="btn btn-primary"
+            [disabled]="!estudianteForm.form.valid || isSaving"
+          >
+            {{ isSaving ? 'Guardando...' : (isEditing ? 'Actualizar' : 'Agregar') }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</section>

--- a/frontend/src/app/features/coordinacion/estudiantes/estudiantes.component.ts
+++ b/frontend/src/app/features/coordinacion/estudiantes/estudiantes.component.ts
@@ -2,8 +2,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
-import { AuthService } from '../../../auth.service';
 
 // Interfaces
 interface Estudiante {
@@ -33,8 +31,6 @@ interface Carrera {
   styleUrls: ['./estudiantes.component.css']
 })
 export class CoordinacionEstudiantesComponent implements OnInit {
-  // Estado del menú
-  menuOpen = true;
 
   // Datos
   estudiantes: Estudiante[] = [];
@@ -134,8 +130,6 @@ export class CoordinacionEstudiantesComponent implements OnInit {
       fechaIngreso: '2020-03-05'
     }
   ];
- constructor(private readonly authService: AuthService, private readonly router: Router) {}
-
   // Inicialización del componente
   ngOnInit(): void {
     this.loadEstudiantes();
@@ -434,28 +428,6 @@ export class CoordinacionEstudiantesComponent implements OnInit {
 
   trackByEstudianteId(index: number, estudiante: Estudiante): number {
     return estudiante.id;
-  }
-
-  // ===== NAVEGACIÓN =====
-
-  toggleMenu(): void {
-    this.menuOpen = !this.menuOpen;
-  }
-
-  navigateTo(section: string): void {
-    console.log(`Navegando a: ${section}`);
-    // TODO: Implementar navegación real con Router
-  }
-
-  logout(): void {
-    if (!confirm('¿Estás seguro de que quieres cerrar sesión?')) {
-      return;
-    }
-
-    this.authService.logout().subscribe({
-      next: () => this.router.navigateByUrl('/auth/login'),
-      error: () => this.router.navigateByUrl('/auth/login'),
-    });
   }
 
   // ===== HELPERS =====

--- a/frontend/src/app/features/coordinacion/layout/coordinacion-layout.component.ts
+++ b/frontend/src/app/features/coordinacion/layout/coordinacion-layout.component.ts
@@ -24,7 +24,37 @@ export class CoordinacionLayoutComponent implements OnDestroy {
 
   readonly navItems: CoordinacionNavItem[] = [
     { route: 'inicio', label: 'Inicio', icon: 'assets/Inicio.png', alt: 'Inicio' },
-    { route: 'practicas', label: 'Prácticas', icon: 'assets/Procesos.png', alt: 'Gestión de prácticas' },
+    {
+      route: 'notificaciones',
+      label: 'Notificaciones',
+      icon: 'assets/Notificaciones.png',
+      alt: 'Notificaciones',
+    },
+    {
+      route: 'bandeja',
+      label: 'Bandeja de Entrada',
+      icon: 'assets/Bandeja_entrada.png',
+      alt: 'Bandeja de entrada',
+    },
+    {
+      route: 'estudiantes',
+      label: 'Estudiantes',
+      icon: 'assets/Estudiantes.png',
+      alt: 'Gestión de estudiantes',
+    },
+    {
+      route: 'docentes',
+      label: 'Docentes',
+      icon: 'assets/Docentes.png',
+      alt: 'Gestión de docentes',
+    },
+    {
+      route: 'practicas',
+      label: 'Prácticas',
+      icon: 'assets/Procesos.png',
+      alt: 'Gestión de prácticas',
+    },
+    { route: 'perfil', label: 'Perfil', icon: 'assets/Perfil.png', alt: 'Perfil de coordinación' },
   ];
 
   private readonly destroy$ = new Subject<void>();


### PR DESCRIPTION
## Summary
- register the coordination layout as the parent for every coordination route and extend its navigation items
- refactor coordination bandeja, notificaciones, perfil, estudiantes and docentes components to drop the duplicated sidebar markup in favour of the shared layout outlet
- refresh component templates and styles so their content fits inside the layout content area

## Testing
- npx ng build

------
https://chatgpt.com/codex/tasks/task_e_68e8b75831c8832c8f35801801ffaa55