### PR TITLE
Generate carta PDF when approving solicitudes

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,10 +1,17 @@
+import io
 import json
 import re
+import textwrap
 import unicodedata
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 
 from django.db.models import Q, Value
 from django.db.models.functions import Replace
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from django.utils.text import slugify
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -39,10 +46,433 @@ REDIRECTS = {
 }
 
 
+FIRMA_FALLBACK = {
+    "nombre": "Coordinación de Carrera — UTEM",
+    "cargo": "",
+    "institucion": "Universidad Tecnologica Metropolitana",
+}
+
+
+FIRMAS_POR_CARRERA = {
+    "Ingeniería Civil en Computación mención Informática": {
+        "nombre": "Víctor Escobar Jeria",
+        "cargo": "Director Escuela de Informática y Jefe de Carrera Ingeniería Civil en Computación mención Informática",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería en Informática": {
+        "nombre": "Patricia Mellado Acevedo",
+        "cargo": "Jefa de Carrera Ingeniería en Informática",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería Civil en Ciencia de Datos": {
+        "nombre": "Jorge Vergara Quezada",
+        "cargo": "Jefe de Carrera Ingeniería Civil en Ciencia de Datos",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería Civil Industrial": {
+        "nombre": "Evelyn Gajardo Gutiérrez",
+        "cargo": "Directora Escuela de Industria y Jefa de Carrera Ingeniería Civil Industrial",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería Industrial": {
+        "nombre": "Alexis Rufatt Zafira",
+        "cargo": "Jefe de Carrera Ingeniería Industrial",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería Civil Electrónica": {
+        "nombre": "Patricio Santos López",
+        "cargo": "Director Escuela de Electrónica y Jefe de Carrera Ingeniería Civil Electrónica / Ingeniería Electrónica",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería Electrónica": {
+        "nombre": "Patricio Santos López",
+        "cargo": "Director Escuela de Electrónica y Jefe de Carrera Ingeniería Civil Electrónica / Ingeniería Electrónica",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería Civil en Mecánica": {
+        "nombre": "Christian Muñoz Valenzuela",
+        "cargo": "Director Escuela de Mecánica",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería en Geomensura": {
+        "nombre": "Juan Toledo Ibarra",
+        "cargo": "Director Escuela de Geomensura",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Bachillerato en Ciencias de la Ingeniería": {
+        "nombre": "Rafael Loyola Berríos",
+        "cargo": "Coordinador del Plan Común de Ingeniería y Jefe de Carrera de Bachillerato en Ciencias de la Ingeniería",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Dibujante Proyectista": {
+        "nombre": "Marcelo Borges Quintanilla",
+        "cargo": "Jefe de Carrera Dibujante Proyectista",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+    "Ingeniería Civil Biomédica": {
+        "nombre": "Raúl Caulier Cisterna",
+        "cargo": "Jefe de Carrera Ingeniería Civil Biomédica",
+        "institucion": "Universidad Tecnologica Metropolitana",
+    },
+}
+
+
+OBJETIVOS_DEFECTO = [
+    "Aplicar conocimientos disciplinares en un contexto profesional real.",
+    "Integrarse a equipos de trabajo, comunicando avances y resultados.",
+    "Cumplir con normas de seguridad, calidad y medioambiente vigentes.",
+    "Elaborar informes técnicos con conclusiones basadas en evidencia.",
+]
+
+
+OBJETIVOS_POR_ESCUELA = {
+    "inf": [
+        "Interactuar con profesionales del área informática y con otros de áreas relacionadas.",
+        "Desarrollar capacidades informáticas que le permitan desenvolverse en el ámbito profesional.",
+        "Comprobar empíricamente la importancia de las tecnologías de información.",
+        "Participar en el diseño y/o implementación de soluciones informáticas.",
+    ],
+    "ind": [
+        "Aplicar metodologías de mejora continua (Lean/Seis Sigma) en procesos productivos o de servicios.",
+        "Levantar y analizar indicadores de gestión (KPI), costos y productividad.",
+        "Participar en la planificación de la cadena de suministro, logística y gestión de inventarios.",
+        "Colaborar en sistemas de gestión de calidad y seguridad industrial.",
+    ],
+    "elec": [
+        "Apoyar el diseño, simulación y pruebas de circuitos electrónicos y sistemas embebidos.",
+        "Implementar e integrar instrumentación, sensores y adquisición de datos.",
+        "Participar en el diseño/ensamble de PCB y protocolos de comunicación.",
+        "Aplicar normas de seguridad y estándares eléctricos en laboratorio y terreno.",
+    ],
+    "mec": [
+        "Apoyar el diseño y análisis mecánico mediante herramientas CAD/CAE.",
+        "Participar en procesos de manufactura, mantenimiento y confiabilidad.",
+        "Realizar análisis térmico y de fluidos en equipos/sistemas cuando aplique.",
+        "Aplicar normas de seguridad industrial en talleres y plantas.",
+    ],
+    "geo": [
+        "Realizar levantamientos topográficos con equipos GNSS/estación total.",
+        "Procesar y validar datos geoespaciales para generar planos y modelos.",
+        "Aplicar técnicas de georreferenciación, nivelación y replanteo.",
+        "Elaborar cartografía y reportes técnicos utilizando SIG.",
+    ],
+    "trans": [
+        "Apoyar estudios de tránsito: aforos, velocidad y nivel de servicio.",
+        "Analizar y modelar la demanda de transporte para la planificación de rutas.",
+        "Colaborar en medidas de seguridad vial e infraestructura asociada.",
+        "Contribuir a la gestión operativa del transporte público/privado.",
+    ],
+}
+
+
+OBJETIVOS_POR_CARRERA = {
+    "Ingeniería Civil Biomédica": [
+        "Apoyar la integración y validación de equipos biomédicos en entornos clínicos.",
+        "Aplicar normas y estándares de seguridad (IEC/ISO) y gestión de riesgos clínicos.",
+        "Desarrollar y/o mantener sistemas de bioinstrumentación y monitoreo.",
+        "Colaborar en interoperabilidad de sistemas de información en salud.",
+    ],
+    "Ingeniería en Alimentos": [
+        "Apoyar el control de calidad bajo BPM y sistema HACCP.",
+        "Realizar análisis fisicoquímicos y/o microbiológicos según protocolos.",
+        "Participar en mejora de procesos y trazabilidad en planta.",
+        "Colaborar en desarrollo o reformulación de productos alimentarios.",
+    ],
+    "Ingeniería Civil Química": [
+        "Participar en operaciones unitarias y control de procesos químicos.",
+        "Apoyar en control de calidad y cumplimiento normativo ambiental.",
+        "Realizar balances de materia y energía y análisis de datos de planta.",
+        "Contribuir a seguridad de procesos y gestión de residuos.",
+    ],
+    "Química Industrial": [
+        "Apoyar en control de calidad y análisis químico instrumental.",
+        "Participar en operación/optimización de procesos y seguridad industrial.",
+        "Gestionar documentación técnica y cumplimiento normativo.",
+        "Colaborar en implementación de mejoras de proceso.",
+    ],
+    "Ingeniería Civil Matemática": [
+        "Aplicar modelamiento matemático a problemas de ingeniería.",
+        "Desarrollar análisis estadístico y métodos de optimización.",
+        "Implementar soluciones computacionales para simulación numérica.",
+        "Elaborar reportes técnicos con interpretación de resultados.",
+    ],
+    "Ingeniería Civil en Ciencia de Datos": [
+        "Adquirir, depurar y preparar datos desde fuentes heterogéneas.",
+        "Construir modelos de analítica/aprendizaje supervisado y no supervisado.",
+        "Validar y evaluar modelos; comunicar hallazgos con visualizaciones.",
+        "Apoyar el despliegue y monitoreo de soluciones de data science.",
+    ],
+    "Ingeniería en Biotecnología": [
+        "Apoyar cultivos, bioprocesos y análisis en laboratorio biotecnológico.",
+        "Aplicar normas de bioseguridad y buenas prácticas de laboratorio.",
+        "Procesar y analizar datos experimentales para toma de decisiones.",
+        "Colaborar en escalamiento o transferencia tecnológica cuando aplique.",
+    ],
+    "Ingeniería en Geomensura": [
+        "Realizar levantamientos topográficos con equipos GNSS/estación total.",
+        "Procesar y validar datos geoespaciales para generar planos y modelos.",
+        "Aplicar técnicas de georreferenciación, nivelación y replanteo.",
+        "Elaborar cartografía y reportes técnicos utilizando SIG.",
+    ],
+}
+
+
 def _limpiar_rut(valor: str | None) -> str:
     if not valor:
         return ""
     return re.sub(r"[^0-9kK]", "", valor)
+
+
+def _formatear_rut(valor: str | None) -> str:
+    limpio = _limpiar_rut(valor)
+    if not limpio:
+        return valor or ""
+
+    cuerpo, dv = limpio[:-1], limpio[-1].upper()
+    if not cuerpo:
+        return dv
+
+    partes = []
+    while len(cuerpo) > 3:
+        partes.insert(0, cuerpo[-3:])
+        cuerpo = cuerpo[:-3]
+    if cuerpo:
+        partes.insert(0, cuerpo)
+    cuerpo_formateado = ".".join(partes)
+    return f"{cuerpo_formateado}-{dv}"
+
+
+def _obtener_firma(carrera: str | None) -> dict[str, str]:
+    if carrera and carrera in FIRMAS_POR_CARRERA:
+        return FIRMAS_POR_CARRERA[carrera]
+    return FIRMA_FALLBACK
+
+
+def _obtener_objetivos(carrera: str | None, escuela_id: str | None) -> list[str]:
+    if carrera and carrera in OBJETIVOS_POR_CARRERA:
+        return OBJETIVOS_POR_CARRERA[carrera]
+    if escuela_id and escuela_id in OBJETIVOS_POR_ESCUELA:
+        return OBJETIVOS_POR_ESCUELA[escuela_id]
+    return OBJETIVOS_DEFECTO
+
+
+def _normalizar_texto_pdf(value: str) -> str:
+    if not value:
+        return ""
+
+    reemplazos = {
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2015": "-",
+        "\u2212": "-",
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u00b7": "-",
+    }
+
+    texto = unicodedata.normalize("NFKC", value)
+    texto = "".join(reemplazos.get(ch, ch) for ch in texto)
+
+    try:
+        texto.encode("latin-1")
+    except UnicodeEncodeError:
+        texto = texto.encode("latin-1", "replace").decode("latin-1")
+
+    return texto
+
+
+def _pdf_wrap(texto: str, ancho: int = 88) -> list[str]:
+    texto = _normalizar_texto_pdf(texto.strip())
+    if not texto:
+        return []
+    return textwrap.wrap(
+        texto,
+        width=ancho,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+
+
+def _pdf_wrap_vineta(texto: str, ancho: int = 88, vineta: str = "-") -> list[str]:
+    texto = _normalizar_texto_pdf(texto.strip())
+    if not texto:
+        return []
+    prefijo = f"{vineta} "
+    return textwrap.wrap(
+        texto,
+        width=ancho,
+        initial_indent=prefijo,
+        subsequent_indent=" " * len(prefijo),
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+
+
+def _pdf_escape_texto(texto: str) -> str:
+    return (
+        texto.replace("\\", "\\\\")
+        .replace("(", "\\(")
+        .replace(")", "\\)")
+    )
+
+
+def _renderizar_pdf_lineas(lineas: list[str]) -> bytes:
+    leading = 16
+    inicio_x = 72
+    inicio_y = 770
+
+    texto_ops: list[str] = [
+        "BT",
+        "/F1 12 Tf",
+        f"1 0 0 1 {inicio_x} {inicio_y} Tm",
+        f"{leading} TL",
+    ]
+
+    for linea in lineas:
+        if not linea:
+            texto_ops.append("T*")
+            continue
+        texto_ops.append(f"({_pdf_escape_texto(_normalizar_texto_pdf(linea))}) Tj")
+        texto_ops.append("T*")
+
+    texto_ops.append("ET")
+
+    contenido = "\n".join(texto_ops).encode("latin-1")
+
+    buffer = io.BytesIO()
+    buffer.write(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+
+    offsets: list[int] = []
+
+    def escribir_objeto(data: bytes) -> None:
+        offsets.append(buffer.tell())
+        buffer.write(data)
+
+    escribir_objeto(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    escribir_objeto(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+    escribir_objeto(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+    )
+
+    flujo = (
+        b"4 0 obj\n<< /Length "
+        + str(len(contenido)).encode("ascii")
+        + b" >>\nstream\n"
+        + contenido
+        + b"\nendstream\nendobj\n"
+    )
+    escribir_objeto(flujo)
+
+    escribir_objeto(b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+
+    xref_pos = buffer.tell()
+    buffer.write(f"xref\n0 {len(offsets) + 1}\n".encode("ascii"))
+    buffer.write(b"0000000000 65535 f \n")
+    for offset in offsets:
+        buffer.write(f"{offset:010d} 00000 n \n".encode("ascii"))
+
+    buffer.write(b"trailer\n<< /Size " + str(len(offsets) + 1).encode("ascii") + b" /Root 1 0 R >>\n")
+    buffer.write(b"startxref\n" + str(xref_pos).encode("ascii") + b"\n%%EOF")
+
+    return buffer.getvalue()
+
+
+def _generar_documento_carta(solicitud: SolicitudCartaPractica) -> str:
+    fecha = timezone.localtime(timezone.now())
+    meses = [
+        "Enero",
+        "Febrero",
+        "Marzo",
+        "Abril",
+        "Mayo",
+        "Junio",
+        "Julio",
+        "Agosto",
+        "Septiembre",
+        "Octubre",
+        "Noviembre",
+        "Diciembre",
+    ]
+    fecha_texto = f"Santiago, {meses[fecha.month - 1]} {fecha.day} del {fecha.year}."
+
+    firma = _obtener_firma(solicitud.alumno_carrera)
+    objetivos = _obtener_objetivos(solicitud.alumno_carrera, solicitud.escuela_id)
+
+    partes_alumno = [solicitud.alumno_nombres or "", solicitud.alumno_apellidos or ""]
+    alumno_nombre = " ".join(parte for parte in partes_alumno if parte).strip() or "Alumno"
+    rut_formateado = _formatear_rut(solicitud.alumno_rut) or (solicitud.alumno_rut or "")
+    carrera_texto = solicitud.alumno_carrera or "Carrera profesional"
+
+    lineas: list[str] = []
+    lineas.extend(_pdf_wrap("Universidad Tecnologica Metropolitana", ancho=72))
+    encabezado = (
+        f"{solicitud.escuela_nombre or ''} - "
+        f"{solicitud.escuela_direccion or ''} - Tel. {solicitud.escuela_telefono or ''}"
+    )
+    lineas.extend(_pdf_wrap(encabezado, ancho=72))
+    lineas.append("")
+
+    lineas.extend(_pdf_wrap(fecha_texto, ancho=72))
+    lineas.append("")
+
+    lineas.extend(_pdf_wrap("Señor"))
+    destinatario = " ".join(
+        parte
+        for parte in [solicitud.dest_nombres or "", solicitud.dest_apellidos or ""]
+        if parte
+    )
+    lineas.extend(_pdf_wrap(destinatario))
+    lineas.extend(_pdf_wrap(solicitud.dest_cargo or ""))
+    lineas.extend(_pdf_wrap(solicitud.dest_empresa or ""))
+    lineas.extend(_pdf_wrap("Presente"))
+    lineas.append("")
+
+    cuerpo_1 = (
+        "Me permito dirigirme a Ud. para presentar al Sr. "
+        f"{alumno_nombre}, RUT {rut_formateado}, alumno regular de la carrera de "
+        f"{carrera_texto} de la Universidad Tecnológica Metropolitana, "
+        "y solicitar su aceptación en calidad de alumno en práctica."
+    )
+    lineas.extend(_pdf_wrap(cuerpo_1))
+    lineas.append("")
+
+    cuerpo_2 = (
+        "Esta práctica tiene una duración de "
+        f"{solicitud.practica_duracion_horas} horas cronológicas y sus objetivos son:"
+    )
+    lineas.extend(_pdf_wrap(cuerpo_2))
+
+    for objetivo in objetivos:
+        lineas.extend(_pdf_wrap_vineta(objetivo))
+
+    lineas.append("")
+    lineas.extend(_pdf_wrap("Le saluda atentamente,"))
+    lineas.append("")
+
+    if firma.get("nombre"):
+        lineas.extend(_pdf_wrap(firma["nombre"]))
+    if firma.get("cargo"):
+        lineas.extend(_pdf_wrap(firma["cargo"]))
+    institucion = firma.get("institucion") or "Universidad Tecnologica Metropolitana"
+    lineas.extend(_pdf_wrap(institucion))
+
+    pdf_bytes = _renderizar_pdf_lineas(lineas)
+
+    base_nombre = f"carta {alumno_nombre}".strip()
+    slug = slugify(base_nombre) or "carta-practica"
+    ruta = f"practicas/cartas/{fecha.year}/carta-{slug}.pdf"
+    ruta_antigua_html = f"practicas/cartas/{fecha.year}/carta-{slug}.html"
+
+    if default_storage.exists(ruta):
+        default_storage.delete(ruta)
+    if default_storage.exists(ruta_antigua_html):
+        default_storage.delete(ruta_antigua_html)
+
+    archivo = ContentFile(pdf_bytes)
+    path = default_storage.save(ruta, archivo)
+    return default_storage.url(path)
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
@@ -586,12 +1016,18 @@ def _buscar_coordinador_por_carrera(carrera: str):
 @permission_classes([AllowAny])
 def aprobar_solicitud_carta_practica(request, pk: int):
     solicitud = get_object_or_404(SolicitudCartaPractica, pk=pk)
-    url = request.data.get("url")
-    solicitud.url_documento = url or None
+    url_param = (request.data.get("url") or "").strip()
+
+    if url_param:
+        documento_url = url_param
+    else:
+        documento_url = _generar_documento_carta(solicitud)
+
+    solicitud.url_documento = documento_url or None
     solicitud.motivo_rechazo = None
     solicitud.estado = "aprobado"
     solicitud.save(update_fields=["estado", "url_documento", "motivo_rechazo", "actualizado_en"])
-    return Response({"status": "ok"})
+    return Response({"status": "ok", "url": solicitud.url_documento})
 
 
 @api_view(["POST"])

--- a/frontend/src/app/features/coordinacion/practicas/practicas.component.ts
+++ b/frontend/src/app/features/coordinacion/practicas/practicas.component.ts
@@ -49,6 +49,11 @@ interface SolicitudCarta {
   meta?: Record<string, unknown> | null;
 }
 
+interface AprobarSolicitudResponse {
+  status: string;
+  url?: string | null;
+}
+
 interface DocumentoCompartidoApi {
   id: number;
   nombre: string;
@@ -526,18 +531,21 @@ export class PracticasComponent {
     const c = this.current();
     if (!c) return;
 
-    const body = this.aprobarForm.value.urlFirmado
+    const body: { url?: string | null } = this.aprobarForm.value.urlFirmado
       ? { url: this.aprobarForm.value.urlFirmado }
       : {};
 
-    this.http.post(`/api/coordinacion/solicitudes-carta/${c.id}/aprobar`, body).subscribe({
-      next: () => {
-        this.toast.set('Solicitud aprobada correctamente.');
-        this.actualizarEstadoLocal(c.id, 'aprobado', body['url']);
-        this.cerrarDetalle();
-      },
-      error: () => this.toast.set('Error al aprobar solicitud.'),
-    });
+    this.http
+      .post<AprobarSolicitudResponse>(`/api/coordinacion/solicitudes-carta/${c.id}/aprobar`, body)
+      .subscribe({
+        next: (res) => {
+          this.toast.set('Solicitud aprobada correctamente.');
+          const nuevaUrl = res?.url ?? (body['url'] as string | null | undefined) ?? null;
+          this.actualizarEstadoLocal(c.id, 'aprobado', nuevaUrl ?? undefined);
+          this.cerrarDetalle();
+        },
+        error: () => this.toast.set('Error al aprobar solicitud.'),
+      });
   }
 
   rechazar() {


### PR DESCRIPTION
## Summary
- replace the carta HTML generator with a PDF builder so approved solicitudes create downloadable PDF files
- normalize carta content and wrap paragraphs/bullets before rendering the PDF stream, cleaning up any legacy HTML files when saving

## Testing
- python backend/manage.py check

------
https://chatgpt.com/codex/tasks/task_e_69028adabb8c832cba1c90602ead4bfb