### PR TITLE
Add confirmation modal before reserving a thesis topic

### DIFF
--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
@@ -579,6 +579,33 @@ textarea {
   margin-top: 0;
 }
 
+.tema-confirmacion__requisitos {
+  padding-top: 10px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.tema-confirmacion__requisitos h6 {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1f2937;
+  letter-spacing: 0.01em;
+}
+
+.tema-confirmacion__requisitos ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #374151;
+  font-size: 13px;
+}
+
+.tema-confirmacion__requisitos li {
+  line-height: 1.4;
+}
+
 @media (max-width: 860px) {
   .grid {
     grid-template-columns: 1fr;

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
@@ -464,6 +464,10 @@
   max-height: 90vh;
   overflow-y: auto;
 }
+.modal.confirm-modal {
+  width: min(520px, 92vw);
+  padding-bottom: 24px;
+}
 .modal-head {
   display: flex;
   align-items: center;
@@ -540,6 +544,39 @@ textarea {
 
 .actions.full {
   grid-column: 1 / -1;
+}
+
+.tema-confirmacion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.tema-confirmacion h5 {
+  margin: 0;
+  font-size: 18px;
+  color: #1a3e6a;
+}
+
+.tema-confirmacion .descripcion {
+  margin: 0;
+}
+
+.tema-confirmacion__autor {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.tema-confirmacion .chips.meta {
+  margin-top: 4px;
+}
+
+.tema-confirmacion .chips.requisitos {
+  margin-top: 0;
 }
 
 @media (max-width: 860px) {

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -194,7 +194,7 @@
                 type="button"
                 class="btn primary sm"
                 [disabled]="!puedePedirTema(tema) || reservandoTemaId() === tema.id"
-                (click)="pedirTema(tema)"
+                (click)="abrirConfirmacionTema(tema)"
               >
                 {{ etiquetaPedirTema(tema) }}
               </button>
@@ -202,6 +202,70 @@
           </ul>
         </ng-template>
 
+
+
+    <div class="backdrop" *ngIf="temaSeleccionado()" (click)="cerrarConfirmacionTema()"></div>
+    <div
+      class="modal confirm-modal"
+      *ngIf="temaSeleccionado() as temaEnConfirmacion"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div class="modal-head">
+        <h4 class="ttl" style="margin: 0">Confirmar reserva</h4>
+        <button class="icon" (click)="cerrarConfirmacionTema()" aria-label="Cerrar">✕</button>
+      </div>
+      <p class="muted" style="margin-top: 0">
+        Revisa los detalles del tema antes de confirmar que deseas reservarlo.
+      </p>
+
+      <div class="tema-confirmacion">
+        <h5>{{ temaEnConfirmacion.titulo }}</h5>
+        <p class="muted descripcion">{{ temaEnConfirmacion.descripcion }}</p>
+
+        <div class="tema-confirmacion__autor" *ngIf="temaEnConfirmacion.creadoPor as autor">
+          <span class="tema-autor__icon" aria-hidden="true">👤</span>
+          <span>
+            {{ autor.rol === 'docente' ? 'Profesor creador' : 'Creado por' }}:
+            <strong class="tema-autor__nombre">{{ autor.nombre }}</strong>
+            · {{ autor.rol | titlecase }}
+            <ng-container *ngIf="autor.carrera"> — {{ autor.carrera }}</ng-container>
+          </span>
+        </div>
+
+        <div class="chips meta">
+          <span class="chip ghost">
+            Cupos disponibles: {{ temaEnConfirmacion.cuposDisponibles }} / {{ temaEnConfirmacion.cupos }}
+          </span>
+          <span class="chip">Carrera: {{ temaEnConfirmacion.carrera }}</span>
+        </div>
+
+        <div class="chips requisitos" *ngIf="temaEnConfirmacion.requisitos?.length">
+          <span class="chip" *ngFor="let req of temaEnConfirmacion.requisitos">{{ req }}</span>
+        </div>
+      </div>
+
+      <div class="err" *ngIf="reservaError()">{{ reservaError() }}</div>
+
+      <div class="actions" style="margin-top: 16px;">
+        <button
+          type="button"
+          class="btn light"
+          (click)="cerrarConfirmacionTema()"
+          [disabled]="reservandoTemaId() === temaEnConfirmacion.id"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          class="btn primary"
+          (click)="confirmarReservaTema()"
+          [disabled]="reservandoTemaId() === temaEnConfirmacion.id"
+        >
+          {{ reservandoTemaId() === temaEnConfirmacion.id ? 'Reservando…' : 'Confirmar reserva' }}
+        </button>
+      </div>
+    </div>
 
 
       <!-- CORREGIDO: usa getter o bracket notation -->

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -240,8 +240,11 @@
           <span class="chip">Carrera: {{ temaEnConfirmacion.carrera }}</span>
         </div>
 
-        <div class="chips requisitos" *ngIf="temaEnConfirmacion.requisitos?.length">
-          <span class="chip" *ngFor="let req of temaEnConfirmacion.requisitos">{{ req }}</span>
+        <div class="tema-confirmacion__requisitos" *ngIf="temaEnConfirmacion.requisitos?.length">
+          <h6>Requisitos del tema</h6>
+          <ul>
+            <li *ngFor="let req of temaEnConfirmacion.requisitos">{{ req }}</li>
+          </ul>
         </div>
       </div>
 

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -198,6 +198,7 @@ export class AlumnoTrabajoComponent {
   private temasCargados = false;
   reservaMensaje = signal<string | null>(null);
   reservaError = signal<string | null>(null);
+  temaSeleccionado = signal<TemaDisponible | null>(null);
   reservandoTemaId = signal<number | null>(null);
   
   propuestas = signal<Propuesta[]>([]);
@@ -365,6 +366,33 @@ export class AlumnoTrabajoComponent {
     return 'Pedir tema';
   }
 
+  abrirConfirmacionTema(tema: TemaDisponible) {
+    if (!this.puedePedirTema(tema)) {
+      return;
+    }
+
+    this.reservaError.set(null);
+    this.temaSeleccionado.set(tema);
+  }
+
+  cerrarConfirmacionTema() {
+    const seleccionado = this.temaSeleccionado();
+    if (seleccionado && this.reservandoTemaId() === seleccionado.id) {
+      return;
+    }
+
+    this.temaSeleccionado.set(null);
+  }
+
+  confirmarReservaTema() {
+    const tema = this.temaSeleccionado();
+    if (!tema) {
+      return;
+    }
+
+    this.pedirTema(tema);
+  }
+
   pedirTema(tema: TemaDisponible) {
     const alumnoId = this.obtenerAlumnoIdActual();
     if (!alumnoId || !tema.id) {
@@ -387,6 +415,7 @@ export class AlumnoTrabajoComponent {
         this.reservaMensaje.set('Cupo reservado correctamente.');
         this.reservaError.set(null);
         this.reservandoTemaId.set(null);
+        this.temaSeleccionado.set(null);
       },
       error: (err) => {
         const detail = err?.error?.detail ?? 'No fue posible reservar el tema. Intenta nuevamente.';


### PR DESCRIPTION
## Summary
- add a confirmation flow that opens a modal before reserving a tema disponible
- display the topic details inside the modal and allow cancelling or confirming the reservation
- adjust styles for the new confirmation dialog to align with existing modal layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6902ac1e88c88324b1980835c0632e99