### PR TITLE
Implement automatic topic notifications

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib import admin
-from .models import Usuario
-from .models import Usuario, PropuestaTema, Notificacion
+
+from .models import Notificacion, PropuestaTema, Usuario
 
 class UsuarioAdminForm(forms.ModelForm):
     # Campo de password tipo <input type="password">
@@ -31,9 +31,6 @@ class UsuarioAdminForm(forms.ModelForm):
 @admin.register(Usuario)
 class UsuarioAdmin(admin.ModelAdmin):
     form = UsuarioAdminForm
-    list_display = ("nombre_completo", "correo", "rol", "carrera", "rut", "telefono")
-    search_fields = ("nombre_completo", "correo", "rut", "rol", "carrera")
-    list_filter = ("rol", "carrera")
     list_display = ("nombre_completo", "correo", "rol", "carrera", "rut", "telefono")
     search_fields = ("nombre_completo", "correo", "rut", "rol", "carrera")
     list_filter = ("rol", "carrera")

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -231,6 +231,8 @@ class Notificacion(models.Model):
     TIPOS = [
         ("propuesta", "Propuesta"),
         ("general", "General"),
+        ("tema", "Tema"),
+        ("inscripcion", "Inscripción"),
     ]
 
     usuario = models.ForeignKey(

--- a/backend/api/notifications.py
+++ b/backend/api/notifications.py
@@ -1,0 +1,189 @@
+"""Utilities to centralize creation and delivery of notifications."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from django.conf import settings
+from django.core.mail import send_mail
+
+from .models import Notificacion, TemaDisponible, Usuario
+
+
+def _default_from_email() -> str:
+    """Return a fallback email address when none is configured."""
+
+    return getattr(settings, "DEFAULT_FROM_EMAIL", "no-reply@trabajo-titulo.local")
+
+
+def registrar_notificacion(
+    usuario: Usuario,
+    titulo: str,
+    mensaje: str,
+    *,
+    tipo: str = "general",
+    meta: dict | None = None,
+    enviar_correo: bool = True,
+) -> Notificacion:
+    """Persist a notification and optionally send it by email."""
+
+    data_meta = dict(meta or {})
+    notificacion = Notificacion.objects.create(
+        usuario=usuario,
+        titulo=titulo,
+        mensaje=mensaje,
+        tipo=tipo,
+        meta=data_meta,
+    )
+
+    if enviar_correo and usuario.correo:
+        send_mail(
+            subject=titulo,
+            message=mensaje,
+            from_email=_default_from_email(),
+            recipient_list=[usuario.correo],
+            fail_silently=True,
+        )
+
+    return notificacion
+
+
+def notificar_reserva_tema(
+    tema: TemaDisponible,
+    alumno: Usuario,
+    *,
+    cupos_disponibles: int,
+    reactivada: bool = False,
+    inscripcion_id: int | None = None,
+) -> None:
+    """Notify the docente and alumno when a reservation is made or reactivated."""
+
+    meta_base = {
+        "evento": "reserva_tema",
+        "tema_id": tema.id,
+        "tema_titulo": tema.titulo,
+        "alumno_id": alumno.id,
+        "cupos_totales": tema.cupos,
+        "cupos_disponibles": cupos_disponibles,
+        "reactivada": reactivada,
+        "inscripcion_id": inscripcion_id,
+    }
+
+    docente = tema.created_by
+    if docente:
+        accion_docente = (
+            "ha reactivado su participación en"
+            if reactivada
+            else "ha solicitado o tomado"
+        )
+        titulo_docente = f"{alumno.nombre_completo} reservó el tema \"{tema.titulo}\""
+        mensaje_docente = (
+            f"El alumno {alumno.nombre_completo} ({alumno.correo}) {accion_docente} "
+            f"el tema \"{tema.titulo}\"."
+        )
+        registrar_notificacion(
+            docente,
+            titulo_docente,
+            mensaje_docente,
+            tipo="tema",
+            meta={**meta_base, "destinatario": "docente", "docente_id": docente.id},
+        )
+
+    if reactivada:
+        titulo_alumno = f"Reserva reactivada para \"{tema.titulo}\""
+        mensaje_alumno = (
+            "Hemos reactivado tu participación en el tema \"{titulo}\". "
+            "El docente ha sido notificado."
+        ).format(titulo=tema.titulo)
+    else:
+        titulo_alumno = f"Solicitud del tema \"{tema.titulo}\" registrada"
+        mensaje_alumno = (
+            "Tu solicitud para participar en el tema \"{titulo}\" fue registrada correctamente. "
+            "El docente será notificado para continuar con el proceso."
+        ).format(titulo=tema.titulo)
+
+    registrar_notificacion(
+        alumno,
+        titulo_alumno,
+        mensaje_alumno,
+        tipo="inscripcion",
+        meta={**meta_base, "destinatario": "alumno"},
+    )
+
+
+def _alumnos_activos(tema: TemaDisponible) -> Iterable[Usuario]:
+    for inscripcion in tema.inscripciones.filter(activo=True).select_related("alumno"):
+        if inscripcion.alumno:
+            yield inscripcion.alumno
+
+
+def notificar_cupos_completados(tema: TemaDisponible) -> None:
+    """Inform recipients when a topic is no longer accepting students."""
+
+    meta_base = {
+        "evento": "cupos_completados",
+        "tema_id": tema.id,
+        "tema_titulo": tema.titulo,
+        "cupos_totales": tema.cupos,
+    }
+
+    docente = tema.created_by
+    if docente:
+        registrar_notificacion(
+            docente,
+            f"El tema \"{tema.titulo}\" completó sus cupos",
+            (
+                f"El tema \"{tema.titulo}\" alcanzó su máximo de {tema.cupos} cupos. "
+                "No es posible aceptar nuevos alumnos."
+            ),
+            tipo="tema",
+            meta={**meta_base, "destinatario": "docente", "docente_id": docente.id},
+        )
+
+    for alumno in _alumnos_activos(tema):
+        registrar_notificacion(
+            alumno,
+            f"Cupos completos en \"{tema.titulo}\"",
+            (
+                f"El tema \"{tema.titulo}\" alcanzó su límite de participantes, "
+                "por lo que ya no admite más incorporaciones."
+            ),
+            tipo="inscripcion",
+            meta={**meta_base, "destinatario": "alumno", "alumno_id": alumno.id},
+        )
+
+
+def notificar_tema_finalizado(tema: TemaDisponible) -> None:
+    """Notify involved users when a topic is closed or removed from the platform."""
+
+    meta_base = {
+        "evento": "tema_finalizado",
+        "tema_id": tema.id,
+        "tema_titulo": tema.titulo,
+        "cupos_totales": tema.cupos,
+    }
+
+    docente = tema.created_by
+    if docente:
+        registrar_notificacion(
+            docente,
+            f"Se cerró el tema \"{tema.titulo}\"",
+            (
+                f"El tema \"{tema.titulo}\" ha sido marcado como finalizado o eliminado "
+                "de la plataforma. Se notificó a los estudiantes asociados."
+            ),
+            tipo="tema",
+            meta={**meta_base, "destinatario": "docente", "docente_id": docente.id},
+        )
+
+    for alumno in _alumnos_activos(tema):
+        registrar_notificacion(
+            alumno,
+            f"Estado final del tema \"{tema.titulo}\"",
+            (
+                f"El proceso asociado al tema \"{tema.titulo}\" finalizó. "
+                "Conserva este mensaje como confirmación del estado final."
+            ),
+            tipo="inscripcion",
+            meta={**meta_base, "destinatario": "alumno", "alumno_id": alumno.id},
+        )

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -81,11 +81,95 @@ class TemaDisponibleAPITestCase(APITestCase):
             created_by=self.usuario,
         )
 
-        response = self.client.get(self.list_url, format="json")
+        response = self.client.get(self.list_url, {"usuario": self.usuario.pk}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["titulo"], "Tema 1")
         self.assertTrue(all("cuposDisponibles" in item for item in response.data))
+
+    def test_list_temas_disponibles_filtra_por_alumno(self):
+        TemaDisponible.objects.create(
+            titulo="Tema 1",
+            carrera="Computación",
+            descripcion="Descripción 1",
+            requisitos=["Req 1"],
+            cupos=2,
+        )
+        TemaDisponible.objects.create(
+            titulo="Tema 2",
+            carrera="Informática",
+            descripcion="Descripción 2",
+            requisitos=["Req 2"],
+            cupos=1,
+        )
+
+        alumno = Usuario.objects.create(
+            nombre_completo="Alumno",
+            correo="alumno@example.com",
+            carrera="Computación",
+            rut="22222222-2",
+            telefono="",
+            rol="alumno",
+            contrasena="clave",
+        )
+
+        response = self.client.get(self.list_url, {"alumno": alumno.pk}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["titulo"], "Tema 1")
+
+    def test_list_temas_disponibles_filtra_normalizando_carrera(self):
+        TemaDisponible.objects.create(
+            titulo="Tema Ñ",
+            carrera="Ingeniería Informática",
+            descripcion="Descripción Ñ",
+            requisitos=["Req"],
+            cupos=2,
+        )
+
+        alumno = Usuario.objects.create(
+            nombre_completo="Alumno Ñ",
+            correo="alumno-tilde@example.com",
+            carrera="Ingenieria Informatica",
+            rut="22222222-3",
+            telefono="",
+            rol="alumno",
+            contrasena="clave",
+        )
+
+        response = self.client.get(self.list_url, {"alumno": alumno.pk}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["titulo"], "Tema Ñ")
+
+    def test_list_temas_disponibles_filtra_por_carrera_query_param(self):
+        TemaDisponible.objects.create(
+            titulo="Tema carrera",
+            carrera="Ingeniería Industrial",
+            descripcion="Descripción",
+            requisitos=["Req"],
+            cupos=2,
+        )
+        TemaDisponible.objects.create(
+            titulo="Tema distinto",
+            carrera="Ingeniería Informática",
+            descripcion="Descripción",
+            requisitos=["Req"],
+            cupos=2,
+        )
+
+        response = self.client.get(
+            self.list_url,
+            {"carrera": "Ingenieria Industrial"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["titulo"], "Tema carrera")
 
     def test_retrieve_tema_disponible(self):
         tema = TemaDisponible.objects.create(
@@ -98,10 +182,35 @@ class TemaDisponibleAPITestCase(APITestCase):
         )
 
         detail_url = reverse("tema-detalle", args=[tema.pk])
-        response = self.client.get(detail_url, format="json")
+        response = self.client.get(detail_url, {"usuario": self.usuario.pk}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["titulo"], "Tema único")
+
+    def test_retrieve_tema_disponible_otro_usuario_no_autorizado(self):
+        tema = TemaDisponible.objects.create(
+            titulo="Tema restringido",
+            carrera="Computación",
+            descripcion="Descripción", 
+            requisitos=["Req"],
+            cupos=1,
+            created_by=self.usuario,
+        )
+
+        otro = Usuario.objects.create(
+            nombre_completo="Docente 2",
+            correo="docente2@example.com",
+            carrera="Informática",
+            rut="44444444-4",
+            telefono="",
+            rol="docente",
+            contrasena="segura",
+        )
+
+        detail_url = reverse("tema-detalle", args=[tema.pk])
+        response = self.client.get(detail_url, {"usuario": otro.pk}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_reservar_tema_descuenta_cupo(self):
         tema = TemaDisponible.objects.create(
@@ -118,6 +227,30 @@ class TemaDisponibleAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["cuposDisponibles"], 1)
         self.assertTrue(response.data["tieneCupoPropio"])
+
+    def test_reservar_tema_otro_carrera_rechazado(self):
+        tema = TemaDisponible.objects.create(
+            titulo="Tema",
+            carrera="Computación",
+            descripcion="Desc",
+            requisitos=["Req"],
+            cupos=2,
+        )
+        alumno = Usuario.objects.create(
+            nombre_completo="Alumno",
+            correo="alumno@example.com",
+            carrera="Informática",
+            rut="55555555-5",
+            telefono="",
+            rol="alumno",
+            contrasena="clave",
+        )
+
+        url = reverse("tema-reservar", args=[tema.pk])
+        response = self.client.post(url, {"alumno": alumno.pk}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
 
     def test_no_permite_reservar_sin_cupos(self):
         tema = TemaDisponible.objects.create(
@@ -405,3 +538,131 @@ class PropuestaTemaDecisionNotificationTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Notificacion.objects.count(), 0)
+
+
+class ReservaTemaNotificationTests(APITestCase):
+    def setUp(self):
+        self.docente = Usuario.objects.create(
+            nombre_completo="Docente Responsable",
+            correo="docente.responsable@example.com",
+            carrera="Computación",
+            rut="70",
+            telefono="555-1111",
+            rol="docente",
+            contrasena="password",
+        )
+        self.alumno = Usuario.objects.create(
+            nombre_completo="Alumno Interesado",
+            correo="alumno.interesado@example.com",
+            carrera="Computación",
+            rut="80",
+            telefono="555-2222",
+            rol="alumno",
+            contrasena="password",
+        )
+        self.tema = TemaDisponible.objects.create(
+            titulo="Análisis de datos",
+            carrera="Computación",
+            descripcion="Descripción",
+            requisitos=["Python"],
+            cupos=2,
+            created_by=self.docente,
+        )
+        self.url = reverse("tema-reservar", args=[self.tema.pk])
+
+    def test_notifica_docente_y_alumno_al_reservar(self):
+        response = self.client.post(self.url, {"alumno": self.alumno.pk}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Notificacion.objects.count(), 2)
+
+        docente_notif = Notificacion.objects.get(usuario=self.docente)
+        self.assertEqual(docente_notif.tipo, "tema")
+        self.assertEqual(docente_notif.meta.get("evento"), "reserva_tema")
+        self.assertEqual(docente_notif.meta.get("alumno_id"), self.alumno.id)
+        inscripcion = self.tema.inscripciones.get(alumno=self.alumno)
+        self.assertEqual(docente_notif.meta.get("inscripcion_id"), inscripcion.id)
+
+        alumno_notif = Notificacion.objects.get(usuario=self.alumno)
+        self.assertEqual(alumno_notif.tipo, "inscripcion")
+        self.assertEqual(alumno_notif.meta.get("evento"), "reserva_tema")
+        self.assertIn("registrada", alumno_notif.titulo.lower())
+
+    def test_notifica_cupos_completados(self):
+        tema = TemaDisponible.objects.create(
+            titulo="Robótica",
+            carrera="Computación",
+            descripcion="",
+            requisitos=[],
+            cupos=1,
+            created_by=self.docente,
+        )
+        url = reverse("tema-reservar", args=[tema.pk])
+
+        response = self.client.post(url, {"alumno": self.alumno.pk}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        docente_notifs = Notificacion.objects.filter(usuario=self.docente)
+        self.assertEqual(docente_notifs.count(), 2)
+        eventos_docente = {n.meta.get("evento") for n in docente_notifs}
+        self.assertEqual(eventos_docente, {"reserva_tema", "cupos_completados"})
+
+        alumno_notifs = Notificacion.objects.filter(usuario=self.alumno)
+        self.assertEqual(alumno_notifs.count(), 2)
+        eventos_alumno = {n.meta.get("evento") for n in alumno_notifs}
+        self.assertEqual(eventos_alumno, {"reserva_tema", "cupos_completados"})
+
+
+class TemaDisponibleFinalizacionNotificationTests(APITestCase):
+    def setUp(self):
+        self.docente = Usuario.objects.create(
+            nombre_completo="Docente Finalizador",
+            correo="docente.finalizador@example.com",
+            carrera="Computación",
+            rut="90",
+            telefono="555-3333",
+            rol="docente",
+            contrasena="password",
+        )
+        self.alumno1 = Usuario.objects.create(
+            nombre_completo="Alumno Uno",
+            correo="alumno.uno@example.com",
+            carrera="Computación",
+            rut="91",
+            telefono="555-4444",
+            rol="alumno",
+            contrasena="password",
+        )
+        self.alumno2 = Usuario.objects.create(
+            nombre_completo="Alumno Dos",
+            correo="alumno.dos@example.com",
+            carrera="Computación",
+            rut="92",
+            telefono="555-5555",
+            rol="alumno",
+            contrasena="password",
+        )
+        self.tema = TemaDisponible.objects.create(
+            titulo="Sistemas distribuidos",
+            carrera="Computación",
+            descripcion="",
+            requisitos=[],
+            cupos=3,
+            created_by=self.docente,
+        )
+        InscripcionTema.objects.create(tema=self.tema, alumno=self.alumno1)
+        InscripcionTema.objects.create(tema=self.tema, alumno=self.alumno2)
+        self.url = reverse("tema-detalle", args=[self.tema.pk])
+
+    def test_notifica_al_cerrar_tema(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        destinatarios = {notif.usuario_id for notif in Notificacion.objects.all()}
+        self.assertSetEqual(
+            destinatarios,
+            {self.docente.id, self.alumno1.id, self.alumno2.id},
+        )
+        eventos = {notif.meta.get("evento") for notif in Notificacion.objects.all()}
+        self.assertEqual(eventos, {"tema_finalizado"})

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -194,7 +194,7 @@
                 type="button"
                 class="btn primary sm"
                 [disabled]="!puedePedirTema(tema) || reservandoTemaId() === tema.id"
-                (click)="pedirTema(tema)"
+                (click)="abrirConfirmacionTema(tema)"
               >
                 {{ etiquetaPedirTema(tema) }}
               </button>
@@ -205,6 +205,33 @@
 
 
       <!-- CORREGIDO: usa getter o bracket notation -->
+    <div class="backdrop" *ngIf="temaSeleccionado()" (click)="cerrarConfirmacionTema()"></div>
+    <div class="modal" *ngIf="temaSeleccionado() as temaEnConfirmacion" role="dialog" aria-modal="true">
+      <div class="modal-head">
+        <h4 class="ttl" style="margin: 0">Confirmar reserva</h4>
+        <button class="icon" (click)="cerrarConfirmacionTema()" aria-label="Cerrar">✕</button>
+      </div>
+      <div class="modal-body">
+        <p>Estás a punto de reservar el tema <strong>{{ temaEnConfirmacion.titulo }}</strong>.</p>
+        <p class="muted">Profesor responsable: {{ temaEnConfirmacion.creadoPor?.nombre || 'Por asignar' }}</p>
+        <div class="chips meta">
+          <span class="chip ghost">Cupos disponibles: {{ temaEnConfirmacion.cuposDisponibles }}</span>
+        </div>
+        <p>¿Deseas continuar?</p>
+      </div>
+      <div class="actions">
+        <button type="button" class="btn light" (click)="cerrarConfirmacionTema()">Cancelar</button>
+        <button
+          type="button"
+          class="btn primary"
+          [disabled]="reservandoTemaId() === temaEnConfirmacion.id"
+          (click)="confirmarReservaTema()"
+        >
+          {{ reservandoTemaId() === temaEnConfirmacion.id ? 'Reservando…' : 'Confirmar' }}
+        </button>
+      </div>
+    </div>
+
     <div class="backdrop" *ngIf="showPostulacion()" (click)="togglePostulacion(false)"></div>
         <div class="modal" *ngIf="showPostulacion()" role="dialog" aria-modal="true">
         <div class="modal-head">

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -334,7 +334,8 @@ export class AlumnoTrabajoComponent {
     this.temasCargando.set(true);
     this.temasError.set(null);
     const alumnoId = this.obtenerAlumnoIdActual();
-    this.temaService.getTemas(alumnoId ?? undefined).subscribe({
+    const opciones = alumnoId != null ? { usuarioId: alumnoId, alumnoId } : undefined;
+    this.temaService.getTemas(opciones).subscribe({
       next: temas => {
         this.temas.set(temas);
         this.temasCargados = true;

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -199,6 +199,7 @@ export class AlumnoTrabajoComponent {
   reservaMensaje = signal<string | null>(null);
   reservaError = signal<string | null>(null);
   reservandoTemaId = signal<number | null>(null);
+  temaPorConfirmar = signal<TemaDisponible | null>(null);
   
   propuestas = signal<Propuesta[]>([]);
   propuestasCargando = signal(false);
@@ -366,11 +367,43 @@ export class AlumnoTrabajoComponent {
     return 'Pedir tema';
   }
 
-  pedirTema(tema: TemaDisponible) {
+  abrirConfirmacionTema(tema: TemaDisponible) {
+    if (!this.puedePedirTema(tema)) {
+      return;
+    }
+
+    this.reservaError.set(null);
+    this.reservaMensaje.set(null);
+    this.temaPorConfirmar.set(tema);
+  }
+
+  temaSeleccionado(): TemaDisponible | null {
+    return this.temaPorConfirmar();
+  }
+
+  cerrarConfirmacionTema() {
+    if (this.reservandoTemaId()) {
+      return;
+    }
+
+    this.temaPorConfirmar.set(null);
+  }
+
+  confirmarReservaTema() {
+    const tema = this.temaPorConfirmar();
+    if (!tema) {
+      return;
+    }
+
+    this.pedirTema(tema);
+  }
+
+  private pedirTema(tema: TemaDisponible) {
     const alumnoId = this.obtenerAlumnoIdActual();
     if (!alumnoId || !tema.id) {
       this.reservaError.set('No se pudo identificar al alumno actual.');
       this.reservaMensaje.set(null);
+      this.temaPorConfirmar.set(null);
       return;
     }
 
@@ -388,12 +421,14 @@ export class AlumnoTrabajoComponent {
         this.reservaMensaje.set('Cupo reservado correctamente.');
         this.reservaError.set(null);
         this.reservandoTemaId.set(null);
+        this.temaPorConfirmar.set(null);
       },
       error: (err) => {
         const detail = err?.error?.detail ?? 'No fue posible reservar el tema. Intenta nuevamente.';
         this.reservaError.set(detail);
         this.reservaMensaje.set(null);
         this.reservandoTemaId.set(null);
+        this.temaPorConfirmar.set(null);
       }
     });
   }

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
@@ -200,7 +200,10 @@ export class DocenteTrabajoListComponent implements OnInit {
     this.temasCargando = true;
     this.temasError = null;
 
-    this.temaService.getTemas()
+    const perfil = this.currentUserService.getProfile();
+    const opciones = perfil?.id != null ? { usuarioId: perfil.id } : undefined;
+
+    this.temaService.getTemas(opciones)
       .pipe(finalize(() => (this.temasCargando = false)))
       .subscribe({
         next: (temasApi: TemaAPI[]) => {

--- a/frontend/src/app/features/docente/trabajolist/tema.service.ts
+++ b/frontend/src/app/features/docente/trabajolist/tema.service.ts
@@ -33,9 +33,26 @@ export class TemaService {
 
   constructor(private http: HttpClient) {}
 
-  getTemas(alumnoId?: number | null): Observable<TemaDisponible[]> {
-    const params = alumnoId ? { alumno: alumnoId } : undefined;
-    return this.http.get<TemaDisponible[]>(this.baseUrl, { params });
+  getTemas(options?: {
+    usuarioId?: number | null;
+    alumnoId?: number | null;
+    carrera?: string | null;
+  }): Observable<TemaDisponible[]> {
+    const params: Record<string, string> = {};
+    const { usuarioId, alumnoId, carrera } = options ?? {};
+
+    if (usuarioId != null) {
+      params['usuario'] = String(usuarioId);
+    }
+    if (alumnoId != null) {
+      params['alumno'] = String(alumnoId);
+    }
+    if (carrera) {
+      params['carrera'] = carrera;
+    }
+
+    const httpOptions = Object.keys(params).length ? { params } : {};
+    return this.http.get<TemaDisponible[]>(this.baseUrl, httpOptions);
   }
 
   crearTema(payload: CrearTemaPayload): Observable<TemaDisponible> {


### PR DESCRIPTION
## Summary
- add notification utilities that centralize email and persistence while expanding topic-related notification types
- trigger automatic notices for new or reactivated reservations, cupos completados, and topic closures so docentes y alumnos stay informed
- extend API coverage to validate reservation confirmations, capacity alerts, and finalization notifications

## Testing
- python manage.py test backend.api.tests.ReservaTemaNotificationTests backend.api.tests.TemaDisponibleFinalizacionNotificationTests --verbosity 2 *(fails: database NAME setting is None in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6901a667c1008324ba3320309261612b