### PR TITLE
feat: reorganize propuestas tab for alumnos

### DIFF
--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
@@ -247,6 +247,12 @@
   color: #047857;
 }
 
+.chip.pending {
+  background: #fff7ed;
+  border-color: #fb923c;
+  color: #b45309;
+}
+
 .alert {
   margin-top: 12px;
   padding: 10px 14px;

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -3,8 +3,8 @@
   <h2 class="ttl">Trabajo de Título</h2>
 
   <div class="tabs">
-    <button [class.active]="tab() === 'i'" (click)="tab.set('i')">T. Título I</button>
-    <button [class.active]="tab() === 'ii'" (click)="tab.set('ii')">T. Título II</button>
+    <button *ngIf="tieneNivel('i')" [class.active]="tab() === 'i'" (click)="tab.set('i')">T. Título I</button>
+    <button *ngIf="tieneNivel('ii')" [class.active]="tab() === 'ii'" (click)="tab.set('ii')">T. Título II</button>
     <button [class.active]="tab() === 'temas'" (click)="tab.set('temas')">Temas</button>
     <button [class.active]="tab() === 'propuestas'" (click)="tab.set('propuestas')">Propuestas</button>
 

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -21,6 +21,40 @@
       </div>
       <p class="muted">Completa el formulario para solicitar o proponer un tema.</p>
 
+      <section class="mis-propuestas">
+        <p class="muted" *ngIf="propuestasCargando()">Actualizando el estado de tus propuestas…</p>
+        <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
+
+        <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
+          <ng-container *ngIf="propuestaDestacada() as propuestaPrincipal; else sinPropuestaDestacada">
+            <div class="propuesta-highlight">
+              <div class="highlight-head">
+                <span class="chip" [ngClass]="chipClasePropuesta(propuestaPrincipal.estado)">
+                  {{ etiquetaPropuestaDestacada(propuestaPrincipal) }}
+                </span>
+                <span class="chip ghost">Actualizada {{ propuestaPrincipal.updatedAt | date:'dd MMM yyyy' }}</span>
+              </div>
+              <h4>{{ propuestaPrincipal.titulo }}</h4>
+              <p class="muted">{{ propuestaPrincipal.descripcion }}</p>
+              <div class="chips">
+                <span class="chip">Rama: {{ propuestaPrincipal.rama }}</span>
+                <span class="chip ghost" *ngIf="propuestaPrincipal.docente">
+                  Docente guía: {{ propuestaPrincipal.docente.nombre }}
+                </span>
+              </div>
+              <p class="comentario" *ngIf="propuestaPrincipal.comentarioDecision">
+                Comentario del docente:
+                <span>{{ propuestaPrincipal.comentarioDecision }}</span>
+              </p>
+            </div>
+          </ng-container>
+        </ng-container>
+      </section>
+
+      <ng-template #sinPropuestaDestacada>
+        <p class="muted">Aún no tienes propuestas aceptadas ni pendientes.</p>
+      </ng-template>
+
       <ng-container *ngIf="temasCargando(); else temasContenido">
         <p class="muted" style="margin-top: 1rem">Cargando temas disponibles...</p>
       </ng-container>
@@ -79,58 +113,35 @@
         <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
 
         <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
-          <ng-container *ngIf="propuestaDestacada() as propuestaPrincipal; else sinPropuestas">
-            <div class="propuesta-highlight">
-              <div class="highlight-head">
-                <span class="chip" [ngClass]="chipClasePropuesta(propuestaPrincipal.estado)">
-                  {{ etiquetaPropuestaDestacada(propuestaPrincipal) }}
-                </span>
-                <span class="chip ghost">Actualizada {{ propuestaPrincipal.updatedAt | date:'dd MMM yyyy' }}</span>
-              </div>
-              <h4>{{ propuestaPrincipal.titulo }}</h4>
-              <p class="muted">{{ propuestaPrincipal.descripcion }}</p>
-              <div class="chips">
-                <span class="chip">Rama: {{ propuestaPrincipal.rama }}</span>
-                <span class="chip ghost" *ngIf="propuestaPrincipal.docente">
-                  Docente guía: {{ propuestaPrincipal.docente.nombre }}
-                </span>
-              </div>
-              <p class="comentario" *ngIf="propuestaPrincipal.comentarioDecision">
-                Comentario del docente:
-                <span>{{ propuestaPrincipal.comentarioDecision }}</span>
-              </p>
-            </div>
-
-            <div class="propuestas-historial" *ngIf="propuestasEnHistorial().length">
-              <h4>Historial de propuestas</h4>
-              <ul class="list propuestas">
-                <li *ngFor="let propuesta of propuestasEnHistorial()">
-                  <div class="grupo-info">
-                    <div class="grupo-nombre">
-                      {{ propuesta.titulo }}
-                      <span class="badge propuesta" [ngClass]="estadoPropuestaClase(propuesta.estado)">
-                        {{ estadoPropuestaTexto[propuesta.estado] }}
-                      </span>
-                    </div>
-                    <div class="grupo-alumnos">{{ propuesta.objetivo }}</div>
-                    <p class="comentario" *ngIf="propuesta.comentarioDecision">
-                      Comentario: <span>{{ propuesta.comentarioDecision }}</span>
-                    </p>
-                    <div class="chips">
-                      <span class="chip ghost">Actualizada {{ propuesta.updatedAt | date:'dd MMM yyyy' }}</span>
-                      <span class="chip ghost" *ngIf="propuesta.docente">Docente: {{ propuesta.docente.nombre }}</span>
-                    </div>
+          <div class="propuestas-historial" *ngIf="propuestasEnHistorial().length; else sinPropuestas">
+            <h4>Historial de propuestas</h4>
+            <ul class="list propuestas">
+              <li *ngFor="let propuesta of propuestasEnHistorial()">
+                <div class="grupo-info">
+                  <div class="grupo-nombre">
+                    {{ propuesta.titulo }}
+                    <span class="badge propuesta" [ngClass]="estadoPropuestaClase(propuesta.estado)">
+                      {{ estadoPropuestaTexto[propuesta.estado] }}
+                    </span>
                   </div>
-                </li>
-              </ul>
-            </div>
-          </ng-container>
+                  <div class="grupo-alumnos">{{ propuesta.objetivo }}</div>
+                  <p class="comentario" *ngIf="propuesta.comentarioDecision">
+                    Comentario: <span>{{ propuesta.comentarioDecision }}</span>
+                  </p>
+                  <div class="chips">
+                    <span class="chip ghost">Actualizada {{ propuesta.updatedAt | date:'dd MMM yyyy' }}</span>
+                    <span class="chip ghost" *ngIf="propuesta.docente">Docente: {{ propuesta.docente.nombre }}</span>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <ng-template #sinPropuestas>
+            <p class="muted">Aún no envías propuestas personalizadas.</p>
+          </ng-template>
         </ng-container>
       </section>
-
-      <ng-template #sinPropuestas>
-        <p class="muted">Aún no envías propuestas personalizadas.</p>
-      </ng-template>
     </ng-container>
     <ng-container *ngSwitchDefault>
       <p class="subtitle">Tu progreso en {{ nivelTitulo() }}</p>

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -21,36 +21,6 @@
       </div>
       <p class="muted">Completa el formulario para solicitar o proponer un tema.</p>
 
-      <section class="mis-propuestas">
-        <p class="muted" *ngIf="propuestasCargando()">Actualizando el estado de tus propuestas…</p>
-        <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
-
-        <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
-          <div class="propuesta-highlight" *ngIf="propuestaAceptadaDestacada() as propuestaAprobada; else sinAprobadas">
-            <div class="highlight-head">
-              <span class="chip success">Propuesta aceptada</span>
-              <span class="chip ghost">Actualizada {{ propuestaAprobada.updatedAt | date:'dd MMM yyyy' }}</span>
-            </div>
-            <h4>{{ propuestaAprobada.titulo }}</h4>
-            <p class="muted">{{ propuestaAprobada.descripcion }}</p>
-            <div class="chips">
-              <span class="chip">Rama: {{ propuestaAprobada.rama }}</span>
-              <span class="chip ghost" *ngIf="propuestaAprobada.docente">
-                Docente guía: {{ propuestaAprobada.docente.nombre }}
-              </span>
-            </div>
-            <p class="comentario" *ngIf="propuestaAprobada.comentarioDecision">
-              Comentario del docente:
-              <span>{{ propuestaAprobada.comentarioDecision }}</span>
-            </p>
-          </div>
-        </ng-container>
-      </section>
-
-      <ng-template #sinAprobadas>
-        <p class="muted">Aún no tienes propuestas aceptadas.</p>
-      </ng-template>
-
       <ng-container *ngIf="temasCargando(); else temasContenido">
         <p class="muted" style="margin-top: 1rem">Cargando temas disponibles...</p>
       </ng-container>
@@ -109,114 +79,124 @@
         <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
 
         <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
-          <div class="propuestas-historial" *ngIf="propuestasEnHistorial().length; else sinPropuestas">
-            <h4>Mis propuestas enviadas</h4>
-            <ul class="list propuestas">
-              <li *ngFor="let propuesta of propuestasEnHistorial()">
-                <div class="grupo-info">
-                  <div class="grupo-nombre">
-                    {{ propuesta.titulo }}
-                    <span class="badge propuesta" [ngClass]="estadoPropuestaClase(propuesta.estado)">
-                      {{ estadoPropuestaTexto[propuesta.estado] }}
-                    </span>
-                  </div>
-                  <div class="grupo-alumnos">{{ propuesta.objetivo }}</div>
-                  <p class="comentario" *ngIf="propuesta.comentarioDecision">
-                    Comentario: <span>{{ propuesta.comentarioDecision }}</span>
-                  </p>
-                  <div class="chips">
-                    <span class="chip ghost">Actualizada {{ propuesta.updatedAt | date:'dd MMM yyyy' }}</span>
-                    <span class="chip ghost" *ngIf="propuesta.docente">Docente: {{ propuesta.docente.nombre }}</span>
-                  </div>
-                </div>
-              </li>
-            </ul>
-          </div>
+          <ng-container *ngIf="propuestaDestacada() as propuestaPrincipal; else sinPropuestas">
+            <div class="propuesta-highlight">
+              <div class="highlight-head">
+                <span class="chip" [ngClass]="chipClasePropuesta(propuestaPrincipal.estado)">
+                  {{ etiquetaPropuestaDestacada(propuestaPrincipal) }}
+                </span>
+                <span class="chip ghost">Actualizada {{ propuestaPrincipal.updatedAt | date:'dd MMM yyyy' }}</span>
+              </div>
+              <h4>{{ propuestaPrincipal.titulo }}</h4>
+              <p class="muted">{{ propuestaPrincipal.descripcion }}</p>
+              <div class="chips">
+                <span class="chip">Rama: {{ propuestaPrincipal.rama }}</span>
+                <span class="chip ghost" *ngIf="propuestaPrincipal.docente">
+                  Docente guía: {{ propuestaPrincipal.docente.nombre }}
+                </span>
+              </div>
+              <p class="comentario" *ngIf="propuestaPrincipal.comentarioDecision">
+                Comentario del docente:
+                <span>{{ propuestaPrincipal.comentarioDecision }}</span>
+              </p>
+            </div>
 
-          <ng-template #sinPropuestas>
-            <p class="muted">Aún no envías propuestas personalizadas.</p>
-          </ng-template>
+            <div class="propuestas-historial" *ngIf="propuestasEnHistorial().length">
+              <h4>Historial de propuestas</h4>
+              <ul class="list propuestas">
+                <li *ngFor="let propuesta of propuestasEnHistorial()">
+                  <div class="grupo-info">
+                    <div class="grupo-nombre">
+                      {{ propuesta.titulo }}
+                      <span class="badge propuesta" [ngClass]="estadoPropuestaClase(propuesta.estado)">
+                        {{ estadoPropuestaTexto[propuesta.estado] }}
+                      </span>
+                    </div>
+                    <div class="grupo-alumnos">{{ propuesta.objetivo }}</div>
+                    <p class="comentario" *ngIf="propuesta.comentarioDecision">
+                      Comentario: <span>{{ propuesta.comentarioDecision }}</span>
+                    </p>
+                    <div class="chips">
+                      <span class="chip ghost">Actualizada {{ propuesta.updatedAt | date:'dd MMM yyyy' }}</span>
+                      <span class="chip ghost" *ngIf="propuesta.docente">Docente: {{ propuesta.docente.nombre }}</span>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </ng-container>
         </ng-container>
       </section>
+
+      <ng-template #sinPropuestas>
+        <p class="muted">Aún no envías propuestas personalizadas.</p>
+      </ng-template>
     </ng-container>
     <ng-container *ngSwitchDefault>
-          <p class="subtitle">Tu progreso en {{ nivelTitulo() }}</p>
+      <p class="subtitle">Tu progreso en {{ nivelTitulo() }}</p>
 
-          <ng-container *ngIf="resumenNivel() as resumen">
-            <div class="chips metrics">
-              <span class="chip highlight">Avance general: {{ resumen.avance }}%</span>
-              <span class="chip ghost">Entregas aprobadas: {{ resumen.aprobadas }} / {{ resumen.totales }}</span>
-              <span class="chip">Próximo hito: {{ resumen.proximoHito }}</span>
-              <span class="chip">Último feedback: {{ resumen.ultimoFeedback }}</span>
-              <span class="chip">Profesor guía: {{ resumen.profesorGuia }}</span>
-            </div>
+      <ng-container *ngIf="resumenNivel() as resumen">
+        <div class="chips metrics">
+          <span class="chip highlight">Avance general: {{ resumen.avance }}%</span>
+          <span class="chip ghost">Entregas aprobadas: {{ resumen.aprobadas }} / {{ resumen.totales }}</span>
+          <span class="chip">Próximo hito: {{ resumen.proximoHito }}</span>
+          <span class="chip">Último feedback: {{ resumen.ultimoFeedback }}</span>
+          <span class="chip">Profesor guía: {{ resumen.profesorGuia }}</span>
+        </div>
       </ng-container>
-            
 
-              <div class="upload-card" *ngIf="entregaDestacada() as destacada; else sinDestacada">
-            <div class="upload-header">
-              <h3>{{ destacada.encabezado }}</h3>
-              <span class="badge" [ngClass]="destacada.estado">{{ destacada.estadoEtiqueta }}</span>
-            </div>
-            <p class="upload-title">{{ destacada.nombre }}</p>
-            <p class="muted">{{ destacada.descripcion }}</p>
-            <div class="chips">
-              <span class="chip">{{ destacada.fecha }}</span>
-              <span class="chip ghost" *ngIf="destacada.proximoPaso">Próximo paso: {{ destacada.proximoPaso }}</span>
-            </div>
-            <div class="upload-actions">
-              <button class="btn primary" routerLink="/alumno/entrega">Gestionar entregas </button>
-            </div>
+      <div class="upload-card" *ngIf="entregaDestacada() as destacada; else sinDestacada">
+        <div class="upload-header">
+          <h3>{{ destacada.encabezado }}</h3>
+          <span class="badge" [ngClass]="destacada.estado">{{ destacada.estadoEtiqueta }}</span>
+        </div>
+        <p class="upload-title">{{ destacada.nombre }}</p>
+        <p class="muted">{{ destacada.descripcion }}</p>
+        <div class="chips">
+          <span class="chip">{{ destacada.fecha }}</span>
+          <span class="chip ghost" *ngIf="destacada.proximoPaso">Próximo paso: {{ destacada.proximoPaso }}</span>
+        </div>
+        <div class="upload-actions">
+          <button class="btn primary" routerLink="/alumno/entrega">Gestionar entregas </button>
+        </div>
+      </div>
+
+      <ng-template #sinDestacada>
+        <div class="upload-card empty">
+          <h3>Sin entregas destacadas</h3>
+          <p class="muted">Cuando registres avances verás aquí un resumen de tu próxima acción.</p>
+          <div class="upload-actions">
+            <a class="btn link" routerLink="/alumno/entrega">Ir a entregas</a>
           </div>
+        </div>
+      </ng-template>
 
-          <ng-template #sinDestacada>
-            <div class="upload-card empty">
-              <h3>Sin entregas destacadas</h3>
-              <p class="muted">Cuando registres avances verás aquí un resumen de tu próxima acción.</p>
-              <div class="upload-actions">
-                <a class="btn link" routerLink="/alumno/entrega">Ir a entregas</a>
+      <h3 class="section-title">Entregas e hitos recientes</h3>
+
+      <ng-container *ngIf="entregasPorNivel().length; else sinEntregas">
+        <ul class="list">
+          <li *ngFor="let item of entregasPorNivel()">
+            <div class="grupo-info">
+              <div class="grupo-nombre">
+                {{ item.nombre }}
+                <span class="badge" [ngClass]="item.estado">{{ estadoTexto[item.estado] }}</span>
+                <span class="badge soft">{{ item.badge }}</span>
+                <span *ngIf="item.alerta" class="alert-icon">{{ item.alerta }}</span>
+                <span *ngIf="item.estado === 'aprobado'" class="status-icon" aria-label="Aprobado">✓</span>
+              </div>
+              <div class="grupo-alumnos">{{ item.descripcion }}</div>
+              <div class="chips">
+                <span class="chip">{{ item.fecha }}</span>
+                <span class="chip ghost" *ngIf="item.proximoPaso">Próximo paso: {{ item.proximoPaso }}</span>
               </div>
             </div>
-          </ng-template>
-       
+          </li>
+        </ul>
+      </ng-container>
 
-          <ng-template #sinDestacada>
-            <div class="upload-card empty">
-              <h3>Sin entregas destacadas</h3>
-              <p class="muted">Cuando registres avances verás aquí un resumen de tu próxima acción.</p>
-              <div class="upload-actions">
-                <a class="btn link" routerLink="/alumno/entrega">Ir a entregas</a>
-              </div>
-            </div>
-          </ng-template>
-
-          <h3 class="section-title">Entregas e hitos recientes</h3>
-
-          <ng-container *ngIf="entregasPorNivel().length; else sinEntregas">
-            <ul class="list">
-              <li *ngFor="let item of entregasPorNivel()">
-                <div class="grupo-info">
-                  <div class="grupo-nombre">
-                    {{ item.nombre }}
-                    <span class="badge" [ngClass]="item.estado">{{ estadoTexto[item.estado] }}</span>
-                    <span class="badge soft">{{ item.badge }}</span>
-                    <span *ngIf="item.alerta" class="alert-icon">{{ item.alerta }}</span>
-                    <span *ngIf="item.estado === 'aprobado'" class="status-icon" aria-label="Aprobado">✓</span>
-                  </div>
-                  <div class="grupo-alumnos">{{ item.descripcion }}</div>
-                  <div class="chips">
-                    <span class="chip">{{ item.fecha }}</span>
-                    <span class="chip ghost" *ngIf="item.proximoPaso">Próximo paso: {{ item.proximoPaso }}</span>
-                  </div>
-                </div>
-              </li>
-            </ul>
-          </ng-container>
-
-          <ng-template #sinEntregas>
-            <p class="muted">Aún no tienes entregas registradas en {{ nivelTitulo() }}.</p>
-          </ng-template>
-        </ng-container>
+      <ng-template #sinEntregas>
+        <p class="muted">Aún no tienes entregas registradas en {{ nivelTitulo() }}.</p>
+      </ng-template>
     </ng-container>
   </ng-container>
 
@@ -274,11 +254,13 @@
         <button class="icon" (click)="togglePostulacion(false)" aria-label="Cerrar">✕</button>
       </div>
 
-      <form [formGroup]="postulacionForm" (ngSubmit)="submitPostulacion()" class="grid" novalidate>
-        <div class="muted" *ngIf="profesoresCargando()">Cargando docentes disponibles...</div>
-        <div class="err" *ngIf="profesoresError()">{{ profesoresError() }}</div>
-        <div class="muted" *ngIf="!profesoresCargando() && !profesoresError() && !profesores().length">Por ahora no hay docentes disponibles en el listado.</div>
-        <div class="err" *ngIf="postulacionError()">{{ postulacionError() }}</div>
+        <form [formGroup]="postulacionForm" (ngSubmit)="submitPostulacion()" class="grid" novalidate>
+          <div class="muted" *ngIf="profesoresCargando()">Cargando docentes disponibles...</div>
+          <div class="err" *ngIf="profesoresError()">{{ profesoresError() }}</div>
+          <div class="muted" *ngIf="!profesoresCargando() && !profesoresError() && !profesores().length">
+            Por ahora no hay docentes disponibles en el listado.
+          </div>
+          <div class="err" *ngIf="postulacionError()">{{ postulacionError() }}</div>
 
         <div class="field full">
           <label for="titulo">Nombre del tema <span class="req">*</span></label>
@@ -341,11 +323,10 @@
 
         <div class="actions full">
           <button type="button" class="btn light" (click)="togglePostulacion(false)">Cancelar</button>
-         <button type="submit" class="btn primary" [disabled]="enviandoPropuesta()">
+          <button type="submit" class="btn primary" [disabled]="enviandoPropuesta()">
             {{ enviandoPropuesta() ? 'Enviando…' : 'Enviar postulación' }}
           </button>
         </div>
       </form>
     </div>
-  </ng-template>
-</div>
+  </div>

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -206,19 +206,30 @@ export class AlumnoTrabajoComponent {
   propuestasError = signal<string | null>(null);
   private propuestasCargadas = false;
 
-  propuestasAceptadas = computed(() => {
-    return this.propuestas()
+  propuestasAceptadas = computed(() =>
+    this.propuestas()
       .filter((p) => p.estado === 'aceptada')
-      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-  });
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+  );
 
-  propuestaAceptadaDestacada = computed(() => {
-    const aceptadas = this.propuestasAceptadas();
-    return aceptadas.length ? aceptadas[0] : null;
+  propuestasPendientes = computed(() =>
+    this.propuestas()
+      .filter((p) => p.estado === 'pendiente')
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+  );
+
+  propuestaDestacada = computed(() => {
+    const aceptada = this.propuestasAceptadas()[0];
+    if (aceptada) {
+      return aceptada;
+    }
+
+    const pendiente = this.propuestasPendientes()[0];
+    return pendiente ?? null;
   });
 
   propuestasEnHistorial = computed(() => {
-    const destacada = this.propuestaAceptadaDestacada();
+    const destacada = this.propuestaDestacada();
     return this.propuestas()
       .filter((propuesta) => !destacada || propuesta.id !== destacada.id)
       .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
@@ -238,6 +249,26 @@ export class AlumnoTrabajoComponent {
       return 'rechazada';
     }
     return 'pendiente';
+  }
+
+  etiquetaPropuestaDestacada(propuesta: Propuesta): string {
+    if (propuesta.estado === 'aceptada') {
+      return 'Propuesta aceptada';
+    }
+    if (propuesta.estado === 'pendiente') {
+      return 'Propuesta pendiente';
+    }
+    return 'Propuesta';
+  }
+
+  chipClasePropuesta(estado: Propuesta['estado']): string {
+    if (estado === 'aceptada') {
+      return 'success';
+    }
+    if (estado === 'pendiente') {
+      return 'pending';
+    }
+    return 'ghost';
   }
 
 


### PR DESCRIPTION
## Summary
- move la gestión de propuestas del alumno a la nueva pestaña Propuestas, dejando Temas solo para la reserva de temas
- destacar la propuesta aceptada o pendiente más reciente y mostrar el historial restante
- añadir estilos para chips de propuestas en estado pendiente

## Testing
- `node node_modules/@angular/cli/bin/ng.js build` *(falla: dependencia jspdf faltante en el proyecto)*

------
https://chatgpt.com/codex/tasks/task_e_6902ec1c7c288324bf5f12c43613910e