### PR TITLE
Add dedicated Temas views for alumno and docente

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -43,6 +43,11 @@ export const routes: Routes = [
           import('./features/docente/trabajolist/docente-trabajo-list.component')
             .then((m) => m.DocenteTrabajoListComponent), },
 
+        { path: 'temas',
+        loadComponent: () =>
+          import('./features/docente/temas/docente-temas.component')
+            .then((m) => m.DocenteTemasComponent), },
+
         { path: 'trabajodetalle',
         loadComponent: () =>
           import('./features/docente/trabajodetalle/docente-trabajo-detalle.component')

--- a/frontend/src/app/features/alumno/alumno.routes.ts
+++ b/frontend/src/app/features/alumno/alumno.routes.ts
@@ -15,6 +15,7 @@ import { AlumnoEvaluationsComponent } from './evaluations/alumno-evaluations.com
 import { AlumnoEntregaComponent } from './entrega/alumno-entrega.component';
 import { AlumnoPracticaComponent } from './practica/alumno-practica.component';
 import { AlumnoViewerComponent } from './viewer/alumno-viewer.component';
+import { AlumnoTemasComponent } from './temas/alumno-temas.component';
 
 export const ALUMNO_ROUTES: Routes = [
   {
@@ -29,6 +30,7 @@ export const ALUMNO_ROUTES: Routes = [
       { path: 'calendar',       component: AlumnoCalendarComponent,      title: 'Alumno | Calendar' },
       { path: 'notifications',  component: AlumnoNotificationsComponent, title: 'Alumno | Notifications' },
       { path: 'trabajo',        component: AlumnoTrabajoComponent,       title: 'Alumno | Trabajo' },
+      { path: 'temas',          component: AlumnoTemasComponent,         title: 'Alumno | Temas' },
       { path: 'perfil',         component: AlumnoPerfilComponent,        title: 'Alumno | Perfil' },
       { path: 'reuniones',      component: AlumnoReunionesComponent,     title: 'Alumno | Reuniones' },
       { path: 'bandeja',        component: AlumnoBandejaComponent,       title: 'Alumno | Bandeja' },

--- a/frontend/src/app/features/alumno/layout/alumno-layout.component.ts
+++ b/frontend/src/app/features/alumno/layout/alumno-layout.component.ts
@@ -33,6 +33,7 @@ export class AlumnoLayoutComponent implements OnDestroy {
     { route: 'entrega', label: 'Entregas', icon: 'assets/Bandeja_entrada.png', alt: 'Entregas' },
     { route: 'evaluations', label: 'Evaluaciones', icon: 'assets/Evaluaciones.png', alt: 'Evaluaciones' },
     { route: 'trabajo', label: 'Trabajo de Título', icon: 'assets/Procesos.png', alt: 'Trabajo de título' },
+    { route: 'temas', label: 'Temas', icon: 'assets/Reportes.png', alt: 'Temas disponibles' },
     { route: 'practica', label: 'Práctica', icon: 'assets/Docentes.png', alt: 'Práctica' },
 
     { route: 'docs', label: 'Documentos', icon: 'assets/Reportes.png', alt: 'Documentos' },

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.css
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.css
@@ -1,0 +1,621 @@
+
+/* Card principal y títulos */
+.card {
+  background: #fff;
+  border: 1px solid #dfe5ee;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.05);
+}
+
+.ttl {
+  color: #1a3e6a;
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.section-title {
+  color: #1a3e6a;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 24px 0 16px;
+}
+
+.subtitle {
+  color: #666;
+  font-size: 14px;
+  margin-bottom: 16px;
+  font-weight: 400;
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 24px;
+  border-bottom: 2px solid #dfe5ee;
+}
+
+.tabs button {
+  border: none;
+  background: transparent;
+  border-bottom: 3px solid transparent;
+  padding: 12px 24px;
+  cursor: pointer;
+  color: #666;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.tabs button.active {
+  background: transparent;
+  color: #00bcd4;
+  font-weight: 600;
+  border-bottom: 3px solid #00bcd4;
+}
+
+
+
+/* Botones */
+.btn {
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-weight: 700;
+  cursor: pointer;
+  border: 1px solid transparent;
+  font-size: 14px;
+}
+.btn.primary {
+  background: #1a56db;
+  color: #fff;
+  box-shadow: 0 6px 18px rgba(26, 86, 219, 0.25);
+}
+.btn.primary:hover {
+  background: #174bb8;
+}
+
+.btn[disabled] {
+  background: #9ca3af;
+  color: #f9fafb;
+  cursor: not-allowed;
+  box-shadow: none;
+  opacity: 0.8;
+}
+
+.btn.sm {
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.btn.light {
+  background: #fff;
+  color: #1f2937;
+  border-color: #e5e7eb;
+}
+.btn.light:hover {
+  background: #f9fafb;
+}
+
+/* Listado de entregas */
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.list li {
+  display: grid;
+  grid-template-columns: 1fr;
+  background: #fff;
+  border: 1px solid #dfe5ee;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  gap: 12px;
+}
+
+.list li:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.grupo-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.grupo-nombre {
+  color: #1a3e6a;
+  font-size: 15px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.grupo-alumnos {
+  color: #4b5563;
+  font-size: 13px;
+}
+
+.tema-autor {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.tema-autor__icon {
+  font-size: 16px;
+}
+
+.tema-autor__nombre {
+  color: #1a3e6a;
+}
+
+.alert-icon {
+  color: #d97706;
+  font-size: 13px;
+}
+
+.status-icon {
+  color: #4caf50;
+  font-size: 16px;
+}
+
+/* Chips y badges */
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 999px;
+  border: 1px solid #cfe2ff;
+  background: #e8f2ff;
+  color: #1a3e6a;
+}
+
+.badge.soft {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  color: #4b5563;
+}
+
+.badge.aprobado {
+  background: #ecfdf5;
+  border-color: #bbf7d0;
+  color: #047857;
+}
+
+.badge.enRevision {
+  background: #fff7ed;
+  border-color: #fcd34d;
+  color: #b45309;
+}
+
+.badge.pendiente {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chips.meta {
+  margin-top: 8px;
+}
+
+.chips.requisitos {
+  margin-top: 6px;
+}
+
+.chip {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 12px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  color: #374151;
+}
+
+.chip.ghost {
+  background: #fff;
+  border-style: dashed;
+}
+
+.chip.highlight {
+  background: #e0f2fe;
+  border-color: #bae6fd;
+  color: #0369a1;
+}
+
+.chip.success {
+  background: #d1fae5;
+  border-color: #34d399;
+  color: #047857;
+}
+
+.chip.pending {
+  background: #fff7ed;
+  border-color: #fb923c;
+  color: #b45309;
+}
+
+.alert {
+  margin-top: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.alert.success {
+  background: #ecfdf5;
+  border: 1px solid #bbf7d0;
+  color: #047857;
+}
+
+.alert.error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+}
+
+.alert + .alert {
+  margin-top: 8px;
+}
+
+.mis-propuestas {
+  margin: 24px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.propuesta-highlight {
+  border: 1px solid #bbf7d0;
+  background: linear-gradient(135deg, rgba(209, 250, 229, 0.9), #ecfeff);
+  border-radius: 14px;
+  padding: 20px;
+  box-shadow: 0 10px 25px rgba(16, 185, 129, 0.18);
+}
+
+.propuesta-highlight .highlight-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.propuesta-highlight h4 {
+  margin: 12px 0 6px;
+  color: #065f46;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.propuesta-highlight .muted {
+  color: #065f46;
+  opacity: 0.85;
+}
+
+.propuesta-highlight .comentario {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.propuesta-highlight .comentario span {
+  font-weight: 600;
+  color: #1a3e6a;
+}
+
+.list.propuestas li {
+  border-color: #e5e7eb;
+}
+
+.propuestas-historial h4 {
+  margin: 0 0 8px;
+  color: #1a3e6a;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.propuestas-historial .comentario {
+  margin: 8px 0;
+  font-size: 13px;
+  color: #374151;
+}
+
+.propuestas-historial .comentario span {
+  font-weight: 600;
+  color: #1a3e6a;
+}
+
+.badge.propuesta {
+  background: #e5edff;
+  border-color: #c7d2fe;
+  color: #1a3e6a;
+}
+
+.badge.propuesta.aceptada {
+  background: #d1fae5;
+  border-color: #34d399;
+  color: #047857;
+}
+
+.badge.propuesta.pendiente {
+  background: #fef3c7;
+  border-color: #f59e0b;
+  color: #92400e;
+}
+
+.badge.propuesta.rechazada {
+  background: #fee2e2;
+  border-color: #f87171;
+  color: #b91c1c;
+}
+
+.list.topics li {
+  grid-template-columns: 1fr auto;
+  align-items: flex-start;
+}
+
+
+.metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+/* Zona de carga */
+.upload-card {
+  border: 1px dashed #cbd5e1;
+  border-radius: 10px;
+  padding: 16px;
+  background: #f8fafc;
+}
+
+.upload-card h3 {
+  margin: 0;
+  color: #1a3e6a;
+  font-size: 16px;
+}
+
+.upload-card.empty {
+  border-style: dashed;
+}
+
+.upload-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.upload-title {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a3e6a;
+}
+
+.upload-actions {
+  margin-top: 16px;
+}
+
+.btn.link {
+  background: transparent;
+  color: #1a56db;
+  border-color: transparent;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.btn.link:hover {
+  background: transparent;
+  text-decoration: underline;
+}
+
+.muted {
+  color: #6b7280;
+  margin-top: 10px;
+  font-size: 13px;
+}
+
+/* Modal */
+
+.row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+/* Modal */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  z-index: 20;
+}
+.modal {
+  position: fixed;
+  z-index: 30;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(900px, 92vw);
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.25);
+  padding: 16px 18px 20px;
+  border: 1px solid #e9eef6;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+.modal.confirm-modal {
+  width: min(520px, 92vw);
+  padding-bottom: 24px;
+}
+.modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.icon {
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+/* Grid del formulario */
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px 14px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+}
+.field.full {
+  grid-column: 1 / -1;
+}
+
+/* Inputs */
+label {
+  font-weight: 700;
+  color: #1a3e6a;
+  margin-bottom: 6px;
+}
+
+.req {
+  color: #ef4444;
+}
+
+input[type='text'],
+textarea,
+select {
+  border: 1px solid #e1e7f0;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  background: #fff;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: #1a56db;
+  box-shadow: 0 0 0 3px rgba(26, 86, 219, 0.12);
+}
+textarea {
+  resize: vertical;
+  min-height: 110px;
+}
+
+/* Errores */
+.err {
+  color: #b91c1c;
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+/* Acciones del modal */
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.actions.full {
+  grid-column: 1 / -1;
+}
+
+.tema-confirmacion {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.tema-confirmacion h5 {
+  margin: 0;
+  font-size: 18px;
+  color: #1a3e6a;
+}
+
+.tema-confirmacion .descripcion {
+  margin: 0;
+}
+
+.tema-confirmacion__autor {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.tema-confirmacion .chips.meta {
+  margin-top: 4px;
+}
+
+.tema-confirmacion .chips.requisitos {
+  margin-top: 0;
+}
+
+.tema-confirmacion__requisitos {
+  padding-top: 10px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.tema-confirmacion__requisitos h6 {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1f2937;
+  letter-spacing: 0.01em;
+}
+
+.tema-confirmacion__requisitos ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #374151;
+  font-size: 13px;
+}
+
+.tema-confirmacion__requisitos li {
+  line-height: 1.4;
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Filtros y búsqueda */

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.html
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.html
@@ -1,0 +1,259 @@
+<div class="card">
+  <h2 class="ttl">Temas de Trabajo de Título</h2>
+
+  <div class="tabs">
+    <button [class.active]="tab() === 'temas'" (click)="tab.set('temas')">Temas disponibles</button>
+    <button [class.active]="tab() === 'propuestas'" (click)="tab.set('propuestas')">Mis propuestas</button>
+    <button class="btn primary sm" type="button" (click)="togglePostulacion(true)">
+      + Postular / Proponer tema
+    </button>
+  </div>
+
+  <ng-container [ngSwitch]="tab()">
+    <ng-container *ngSwitchCase="'temas'">
+      <p class="muted">Explora los temas disponibles para postular a tu trabajo de título.</p>
+
+      <ng-container *ngIf="temasCargando(); else temasContenido">
+        <p class="muted" style="margin-top: 1rem">Cargando temas disponibles...</p>
+      </ng-container>
+
+      <ng-template #temasContenido>
+        <div class="err" *ngIf="temasError(); else temasLista">{{ temasError() }}</div>
+      </ng-template>
+
+      <ng-template #sinTemas>
+        <p class="muted" style="margin-top: 1rem">Aún no hay temas disponibles.</p>
+      </ng-template>
+
+      <ng-template #temasLista>
+        <div class="alert success" *ngIf="reservaMensaje()">{{ reservaMensaje() }}</div>
+        <div class="alert error" *ngIf="reservaError()">{{ reservaError() }}</div>
+
+        <ul class="list topics" *ngIf="temas().length; else sinTemas">
+          <li *ngFor="let tema of temas()">
+            <div class="grupo-info">
+              <div class="grupo-nombre">
+                {{ tema.titulo }}
+                <span class="badge">{{ tema.carrera }}</span>
+              </div>
+              <div class="grupo-alumnos">{{ tema.descripcion }}</div>
+              <div class="tema-autor" *ngIf="tema.creadoPor as autor">
+                <span class="tema-autor__icon" aria-hidden="true">👤</span>
+                <span>
+                  {{ autor.rol === 'docente' ? 'Profesor creador' : 'Creado por' }}:
+                  <strong class="tema-autor__nombre">{{ autor.nombre }}</strong>
+                  · {{ autor.rol | titlecase }}
+                  <ng-container *ngIf="autor.carrera"> — {{ autor.carrera }}</ng-container>
+                </span>
+              </div>
+              <div class="chips meta">
+                <span class="chip ghost">Cupos disp.: {{ tema.cuposDisponibles }} / {{ tema.cupos }}</span>
+                <span class="chip success" *ngIf="tema.tieneCupoPropio">Tu cupo reservado</span>
+              </div>
+              <div class="chips requisitos" *ngIf="tema.requisitos?.length">
+                <span class="chip" *ngFor="let req of tema.requisitos">{{ req }}</span>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="btn primary sm"
+              [disabled]="!puedePedirTema(tema) || reservandoTemaId() === tema.id"
+              (click)="abrirConfirmacionTema(tema)"
+            >
+              {{ etiquetaPedirTema(tema) }}
+            </button>
+          </li>
+        </ul>
+      </ng-template>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="'propuestas'">
+      <section class="mis-propuestas">
+        <p class="muted" *ngIf="propuestasCargando()">Actualizando el estado de tus propuestas…</p>
+        <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
+
+        <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
+          <ng-container *ngIf="propuestaDestacada() as propuestaPrincipal">
+            <div class="propuesta-highlight">
+              <div class="highlight-head">
+                <span class="chip" [ngClass]="chipClasePropuesta(propuestaPrincipal.estado)">
+                  {{ etiquetaPropuestaDestacada(propuestaPrincipal) }}
+                </span>
+                <span class="chip ghost">Actualizada {{ propuestaPrincipal.updatedAt | date:'dd MMM yyyy' }}</span>
+              </div>
+              <h4>{{ propuestaPrincipal.titulo }}</h4>
+              <p class="muted">{{ propuestaPrincipal.descripcion }}</p>
+              <div class="chips">
+                <span class="chip">Rama: {{ propuestaPrincipal.rama }}</span>
+                <span class="chip ghost" *ngIf="propuestaPrincipal.docente">
+                  Docente guía: {{ propuestaPrincipal.docente.nombre }}
+                </span>
+              </div>
+              <p class="comentario" *ngIf="propuestaPrincipal.comentarioDecision">
+                Comentario del docente:
+                <span>{{ propuestaPrincipal.comentarioDecision }}</span>
+              </p>
+            </div>
+          </ng-container>
+
+          <div class="propuestas-historial" *ngIf="propuestasEnHistorial().length; else sinPropuestas">
+            <h4>Historial de propuestas</h4>
+            <ul class="list propuestas">
+              <li *ngFor="let propuesta of propuestasEnHistorial()">
+                <div class="grupo-info">
+                  <div class="grupo-nombre">
+                    {{ propuesta.titulo }}
+                    <span class="badge propuesta" [ngClass]="estadoPropuestaClase(propuesta.estado)">
+                      {{ estadoPropuestaTexto[propuesta.estado] }}
+                    </span>
+                  </div>
+                  <div class="grupo-alumnos">{{ propuesta.objetivo }}</div>
+                  <p class="comentario" *ngIf="propuesta.comentarioDecision">
+                    Comentario: <span>{{ propuesta.comentarioDecision }}</span>
+                  </p>
+                  <div class="chips">
+                    <span class="chip ghost">Actualizada {{ propuesta.updatedAt | date:'dd MMM yyyy' }}</span>
+                    <span class="chip ghost" *ngIf="propuesta.docente">Docente: {{ propuesta.docente.nombre }}</span>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <ng-template #sinPropuestas>
+            <p class="muted">Aún no envías propuestas personalizadas.</p>
+          </ng-template>
+        </ng-container>
+      </section>
+    </ng-container>
+  </ng-container>
+</div>
+
+<div class="backdrop" *ngIf="temaSeleccionado()" (click)="cerrarConfirmacionTema()"></div>
+<div class="modal confirm-modal" *ngIf="temaSeleccionado() as temaEnConfirmacion" role="dialog" aria-modal="true">
+  <div class="modal-head">
+    <h4 class="ttl" style="margin: 0">Confirmar reserva</h4>
+    <button class="icon" (click)="cerrarConfirmacionTema()" aria-label="Cerrar">✕</button>
+  </div>
+  <div class="modal-body tema-confirmacion">
+    <div class="chips meta">
+      <span class="chip ghost">Cupos disponibles: {{ temaEnConfirmacion.cuposDisponibles }} / {{ temaEnConfirmacion.cupos }}</span>
+      <span class="chip ghost">Carrera: {{ temaEnConfirmacion.carrera }}</span>
+    </div>
+    <div>
+      <h5>{{ temaEnConfirmacion.titulo }}</h5>
+      <p class="descripcion">{{ temaEnConfirmacion.descripcion }}</p>
+    </div>
+    <div class="tema-confirmacion__autor">
+      <span aria-hidden="true">👤</span>
+      <span>
+        Profesor responsable:
+        <strong>{{ temaEnConfirmacion.creadoPor?.nombre || 'Por asignar' }}</strong>
+      </span>
+    </div>
+    <div class="tema-confirmacion__requisitos" *ngIf="temaEnConfirmacion.requisitos?.length; else sinRequisitos">
+      <h6>Requisitos del tema</h6>
+      <ul>
+        <li *ngFor="let requisito of temaEnConfirmacion.requisitos">{{ requisito }}</li>
+      </ul>
+    </div>
+    <ng-template #sinRequisitos>
+      <p class="muted" style="margin: 0">Este tema no especifica requisitos adicionales.</p>
+    </ng-template>
+    <p>¿Deseas continuar con la reserva?</p>
+  </div>
+  <div class="actions">
+    <button type="button" class="btn light" (click)="cerrarConfirmacionTema()">Cancelar</button>
+    <button
+      type="button"
+      class="btn primary"
+      [disabled]="reservandoTemaId() === temaEnConfirmacion.id"
+      (click)="confirmarReservaTema()"
+    >
+      {{ reservandoTemaId() === temaEnConfirmacion.id ? 'Reservando…' : 'Confirmar' }}
+    </button>
+  </div>
+</div>
+
+<div class="backdrop" *ngIf="showPostulacion()" (click)="togglePostulacion(false)"></div>
+<div class="modal" *ngIf="showPostulacion()" role="dialog" aria-modal="true">
+  <div class="modal-head">
+    <h4 class="ttl" style="margin: 0">Solicitud de Tema</h4>
+    <button class="icon" (click)="togglePostulacion(false)" aria-label="Cerrar">✕</button>
+  </div>
+
+  <form [formGroup]="postulacionForm" (ngSubmit)="submitPostulacion()" class="grid" novalidate>
+    <div class="muted" *ngIf="profesoresCargando()">Cargando docentes disponibles...</div>
+    <div class="err" *ngIf="profesoresError()">{{ profesoresError() }}</div>
+    <div class="muted" *ngIf="!profesoresCargando() && !profesoresError() && !profesores().length">
+      Por ahora no hay docentes disponibles en el listado.
+    </div>
+    <div class="err" *ngIf="postulacionError()">{{ postulacionError() }}</div>
+
+    <div class="field full">
+      <label for="titulo">Nombre del tema <span class="req">*</span></label>
+      <input id="titulo" type="text" formControlName="titulo" />
+      <div class="err" *ngIf="hasError('titulo','required')">Obligatorio.</div>
+      <div class="err" *ngIf="hasError('titulo','maxlength')">Máx. 160 caracteres.</div>
+    </div>
+
+    <div class="field full">
+      <label for="objetivo">Objetivo <span class="req">*</span></label>
+      <input id="objetivo" type="text" formControlName="objetivo" />
+      <div class="err" *ngIf="hasError('objetivo','required')">Obligatorio.</div>
+      <div class="err" *ngIf="hasError('objetivo','maxlength')">Máx. 300 caracteres.</div>
+    </div>
+
+    <div class="field full">
+      <label for="descripcion">Breve descripción <span class="req">*</span></label>
+      <textarea id="descripcion" rows="5" formControlName="descripcion"></textarea>
+      <div class="err" *ngIf="hasError('descripcion','required')">Obligatorio.</div>
+      <div class="err" *ngIf="hasError('descripcion','maxlength')">Máx. 1200 caracteres.</div>
+    </div>
+
+    <div class="field">
+      <label for="rama">Rama de la carrera <span class="req">*</span></label>
+      <select id="rama" formControlName="rama">
+        <option value="" disabled>Selecciona una rama</option>
+        <option *ngFor="let r of ramas" [value]="r">{{ r }}</option>
+      </select>
+      <div class="err" *ngIf="hasError('rama','required')">Selecciona una rama.</div>
+    </div>
+
+    <div class="field">
+      <label for="prof1">Profesor guía (Preferencia 1) <span class="req">*</span></label>
+      <select id="prof1" formControlName="prof1">
+        <option value="" disabled>Selecciona</option>
+        <option *ngFor="let p of profesoresFiltrados()" [value]="p.id">{{ p.nombre }}</option>
+      </select>
+      <div class="err" *ngIf="hasError('prof1','required')">Selecciona una opción.</div>
+    </div>
+
+    <div class="field">
+      <label for="prof2">Profesor guía (Preferencia 2)</label>
+      <select id="prof2" formControlName="prof2">
+        <option value="">(Opcional)</option>
+        <option *ngFor="let p of profesoresFiltrados()" [value]="p.id">{{ p.nombre }}</option>
+      </select>
+    </div>
+
+    <div class="field">
+      <label for="prof3">Profesor guía (Preferencia 3)</label>
+      <select id="prof3" formControlName="prof3">
+        <option value="">(Opcional)</option>
+        <option *ngFor="let p of profesoresFiltrados()" [value]="p.id">{{ p.nombre }}</option>
+      </select>
+    </div>
+
+    <div class="field full" *ngIf="profesoresDuplicados">
+      <span class="err">Las preferencias no pueden repetir al mismo profesor.</span>
+    </div>
+
+    <div class="actions full">
+      <button type="button" class="btn light" (click)="togglePostulacion(false)">Cancelar</button>
+      <button type="submit" class="btn primary" [disabled]="enviandoPropuesta()">
+        {{ enviandoPropuesta() ? 'Enviando…' : 'Enviar postulación' }}
+      </button>
+    </div>
+  </form>
+</div>

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
@@ -1,0 +1,449 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, effect, signal } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { TemaService, TemaDisponible } from '../../docente/trabajolist/tema.service';
+import { PropuestaService, Propuesta } from '../../../shared/services/propuesta.service';
+import { DocentesService, Docente } from '../../../shared/services/docentes.service';
+import { CurrentUserService } from '../../../shared/services/current-user.service';
+
+export type RamaCarrera =
+  | 'Desarrollo de Software' | 'Sistemas de Información'
+  | 'Inteligencia de Negocios' | 'Ciencia de Datos'
+  | 'Redes y Seguridad' | 'Otra';
+
+type Tab = 'temas' | 'propuestas';
+
+interface Profesor {
+  id: number;
+  nombre: string;
+  carrera: string | null;
+  telefono: string | null;
+  ramas: RamaCarrera[] | null;
+}
+
+@Component({
+  selector: 'alumno-temas',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './alumno-temas.component.html',
+  styleUrls: ['./alumno-temas.component.css'],
+})
+export class AlumnoTemasComponent {
+  readonly tab = signal<Tab>('temas');
+
+  readonly temas = signal<TemaDisponible[]>([]);
+  readonly temasCargando = signal(false);
+  readonly temasError = signal<string | null>(null);
+  private temasCargados = false;
+
+  readonly propuestas = signal<Propuesta[]>([]);
+  readonly propuestasCargando = signal(false);
+  readonly propuestasError = signal<string | null>(null);
+  private propuestasCargadas = false;
+
+  readonly reservaMensaje = signal<string | null>(null);
+  readonly reservaError = signal<string | null>(null);
+  readonly reservandoTemaId = signal<number | null>(null);
+  readonly temaPorConfirmar = signal<TemaDisponible | null>(null);
+
+  readonly showPostulacion = signal(false);
+
+  readonly ramas: RamaCarrera[] = [
+    'Desarrollo de Software',
+    'Sistemas de Información',
+    'Inteligencia de Negocios',
+    'Ciencia de Datos',
+    'Redes y Seguridad',
+    'Otra',
+  ];
+
+  readonly profesores = signal<Profesor[]>([]);
+  readonly profesoresCargando = signal(false);
+  readonly profesoresError = signal<string | null>(null);
+
+  readonly enviandoPropuesta = signal(false);
+  readonly postulacionError = signal<string | null>(null);
+
+  readonly postulacionForm: FormGroup;
+
+  readonly profesoresFiltrados = computed(() => {
+    const rama = this.postulacionForm.get('rama')?.value as RamaCarrera | '';
+    const lista = this.profesores();
+    if (!rama) {
+      return lista;
+    }
+    return lista.filter((p) => !p.ramas?.length || p.ramas.includes(rama));
+  });
+
+  readonly propuestasAceptadas = computed(() =>
+    this.propuestas()
+      .filter((p) => p.estado === 'aceptada')
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()),
+  );
+
+  readonly propuestasPendientes = computed(() =>
+    this.propuestas()
+      .filter((p) => p.estado === 'pendiente')
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()),
+  );
+
+  readonly propuestaDestacada = computed(() => {
+    const aceptada = this.propuestasAceptadas()[0];
+    if (aceptada) {
+      return aceptada;
+    }
+    const pendiente = this.propuestasPendientes()[0];
+    return pendiente ?? null;
+  });
+
+  readonly propuestasEnHistorial = computed(() => {
+    const destacada = this.propuestaDestacada();
+    return this.propuestas()
+      .filter((propuesta) => !destacada || propuesta.id !== destacada.id)
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  });
+
+  readonly estadoPropuestaTexto: Record<Propuesta['estado'], string> = {
+    pendiente: 'Pendiente',
+    aceptada: 'Aceptada',
+    rechazada: 'Rechazada',
+  };
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly temaService: TemaService,
+    private readonly propuestaService: PropuestaService,
+    private readonly docentesService: DocentesService,
+    private readonly currentUserService: CurrentUserService,
+  ) {
+    this.postulacionForm = this.fb.group(
+      {
+        titulo: ['', [Validators.required, Validators.maxLength(160)]],
+        objetivo: ['', [Validators.required, Validators.maxLength(300)]],
+        descripcion: ['', [Validators.required, Validators.maxLength(1200)]],
+        rama: ['', Validators.required],
+        prof1: ['', Validators.required],
+        prof2: [''],
+        prof3: [''],
+      },
+      { validators: this.profesoresDistintosValidator },
+    );
+
+    effect(() => {
+      const currentTab = this.tab();
+      if (currentTab === 'temas') {
+        this.reservaMensaje.set(null);
+        this.reservaError.set(null);
+        this.intentarCargarTemas();
+      }
+
+      if (currentTab === 'temas' || currentTab === 'propuestas') {
+        this.intentarCargarPropuestas();
+      }
+    });
+
+    effect(() => {
+      const shouldDisable = this.profesoresCargando() || !this.profesores().length;
+      this.actualizarEstadoControlesProfesores(shouldDisable);
+    });
+  }
+
+  get profesoresDuplicados() {
+    return this.postulacionForm.errors?.['profesoresDuplicados'];
+  }
+
+  chipClasePropuesta(estado: Propuesta['estado']): string {
+    if (estado === 'aceptada') {
+      return 'success';
+    }
+    if (estado === 'pendiente') {
+      return 'pending';
+    }
+    return 'ghost';
+  }
+
+  estadoPropuestaClase(estado: Propuesta['estado']): string {
+    if (estado === 'aceptada') {
+      return 'aceptada';
+    }
+    if (estado === 'rechazada') {
+      return 'rechazada';
+    }
+    return 'pendiente';
+  }
+
+  etiquetaPropuestaDestacada(propuesta: Propuesta): string {
+    if (propuesta.estado === 'aceptada') {
+      return 'Propuesta aceptada';
+    }
+    if (propuesta.estado === 'pendiente') {
+      return 'Propuesta pendiente';
+    }
+    return 'Propuesta';
+  }
+
+  togglePostulacion(open: boolean) {
+    this.showPostulacion.set(open);
+    if (open) {
+      this.cargarProfesores();
+      return;
+    }
+
+    this.postulacionForm.reset();
+    this.postulacionError.set(null);
+  }
+
+  puedePedirTema(tema: TemaDisponible): boolean {
+    return tema.cuposDisponibles > 0 && !tema.tieneCupoPropio;
+  }
+
+  etiquetaPedirTema(tema: TemaDisponible): string {
+    if (tema.tieneCupoPropio) {
+      return 'Cupo reservado';
+    }
+    if (tema.cuposDisponibles === 0) {
+      return 'Sin cupos';
+    }
+    if (this.reservandoTemaId() === tema.id) {
+      return 'Reservando…';
+    }
+    return 'Pedir tema';
+  }
+
+  temaSeleccionado(): TemaDisponible | null {
+    return this.temaPorConfirmar();
+  }
+
+  abrirConfirmacionTema(tema: TemaDisponible) {
+    if (!this.puedePedirTema(tema)) {
+      return;
+    }
+
+    this.reservaError.set(null);
+    this.reservaMensaje.set(null);
+    this.temaPorConfirmar.set(tema);
+  }
+
+  cerrarConfirmacionTema() {
+    if (this.reservandoTemaId()) {
+      return;
+    }
+
+    this.temaPorConfirmar.set(null);
+  }
+
+  confirmarReservaTema() {
+    const tema = this.temaPorConfirmar();
+    if (!tema) {
+      return;
+    }
+
+    this.pedirTema(tema);
+  }
+
+  hasError(ctrl: string, err: string) {
+    const c = this.postulacionForm.get(ctrl);
+    return !!(c && c.touched && c.hasError(err));
+  }
+
+  private pedirTema(tema: TemaDisponible) {
+    const alumnoId = this.obtenerAlumnoIdActual();
+    if (!alumnoId || !tema.id) {
+      this.reservaError.set('No se pudo identificar al alumno actual.');
+      this.reservaMensaje.set(null);
+      return;
+    }
+
+    this.reservandoTemaId.set(tema.id);
+    this.temaService.pedirTema(tema.id, alumnoId).subscribe({
+      next: (actualizado) => {
+        this.temas.set(
+          this.temas().map((t) => (t.id === actualizado.id ? actualizado : t)),
+        );
+        this.reservaMensaje.set('Tu reserva fue registrada correctamente.');
+        this.reservaError.set(null);
+        this.temaPorConfirmar.set(null);
+        this.reservandoTemaId.set(null);
+      },
+      error: (err) => {
+        console.error('Error al reservar tema', err);
+        this.reservaError.set('No fue posible reservar el tema. Intenta nuevamente.');
+        this.reservaMensaje.set(null);
+        this.reservandoTemaId.set(null);
+      },
+    });
+  }
+
+  private intentarCargarTemas() {
+    if (this.temasCargados || this.temasCargando()) {
+      return;
+    }
+
+    this.temasCargando.set(true);
+    this.temasError.set(null);
+
+    const alumnoId = this.obtenerAlumnoIdActual();
+    const opciones = alumnoId != null ? { usuarioId: alumnoId, alumnoId } : undefined;
+
+    this.temaService.getTemas(opciones).subscribe({
+      next: (temas) => {
+        this.temas.set(temas);
+        this.temasCargados = true;
+        this.temasCargando.set(false);
+      },
+      error: (err) => {
+        console.error('Error al cargar temas disponibles', err);
+        this.temasError.set('No fue posible cargar los temas disponibles. Intenta nuevamente más tarde.');
+        this.temasCargando.set(false);
+      },
+    });
+  }
+
+  private intentarCargarPropuestas() {
+    if (this.propuestasCargadas || this.propuestasCargando()) {
+      return;
+    }
+
+    const perfil = this.currentUserService.getProfile();
+    const alumnoId = perfil?.id ?? null;
+    if (!alumnoId) {
+      this.propuestasCargadas = true;
+      this.propuestas.set([]);
+      return;
+    }
+
+    this.propuestasCargando.set(true);
+    this.propuestasError.set(null);
+
+    this.propuestaService.listarPorAlumno(alumnoId).subscribe({
+      next: (propuestas) => {
+        this.propuestas.set(propuestas);
+        this.propuestasCargadas = true;
+        this.propuestasCargando.set(false);
+      },
+      error: (err) => {
+        console.error('Error al cargar tus propuestas', err);
+        this.propuestasError.set('No fue posible cargar tus propuestas. Intenta nuevamente.');
+        this.propuestasCargando.set(false);
+      },
+    });
+  }
+
+  submitPostulacion() {
+    if (this.postulacionForm.invalid) {
+      this.postulacionForm.markAllAsTouched();
+      return;
+    }
+
+    const titulo = this.postulacionForm.value.titulo.trim();
+    const objetivo = this.postulacionForm.value.objetivo.trim();
+    const descripcion = this.postulacionForm.value.descripcion.trim();
+    const rama = this.postulacionForm.value.rama as RamaCarrera;
+
+    const preferenciasValores = [
+      this.postulacionForm.value.prof1,
+      this.postulacionForm.value.prof2,
+      this.postulacionForm.value.prof3,
+    ].filter((v): v is string | number => v !== null && v !== '');
+
+    const preferencias = preferenciasValores.map((id) => Number(id));
+    const perfil = this.currentUserService.getProfile();
+
+    this.enviandoPropuesta.set(true);
+    this.postulacionError.set(null);
+
+    this.propuestaService
+      .crearPropuesta({
+        alumnoId: perfil?.id ?? null,
+        titulo,
+        objetivo,
+        descripcion,
+        rama,
+        preferenciasDocentes: preferencias,
+        docenteId: preferencias.length ? preferencias[0] : null,
+      })
+      .subscribe({
+        next: () => {
+          alert('Tu postulación fue enviada para revisión.');
+          this.togglePostulacion(false);
+          this.enviandoPropuesta.set(false);
+          this.propuestasCargadas = false;
+          this.intentarCargarPropuestas();
+        },
+        error: (err) => {
+          console.error('No fue posible enviar la propuesta', err);
+          this.postulacionError.set('No fue posible enviar la postulación. Intenta nuevamente.');
+          this.enviandoPropuesta.set(false);
+        },
+      });
+  }
+
+  private actualizarEstadoControlesProfesores(desactivar: boolean) {
+    const controles = ['prof1', 'prof2', 'prof3'];
+    controles.forEach((nombre) => {
+      const control = this.postulacionForm.get(nombre);
+      if (!control) {
+        return;
+      }
+
+      if (desactivar) {
+        if (control.enabled) {
+          control.disable({ emitEvent: false });
+        }
+        return;
+      }
+
+      if (control.disabled) {
+        control.enable({ emitEvent: false });
+      }
+    });
+  }
+
+  private cargarProfesores() {
+    if (this.profesores().length || this.profesoresCargando()) {
+      return;
+    }
+
+    const perfil = this.currentUserService.getProfile();
+    const carrera = perfil?.carrera ?? undefined;
+
+    this.profesoresCargando.set(true);
+    this.profesoresError.set(null);
+
+    this.docentesService.listar(carrera ?? undefined).subscribe({
+      next: (docentes: Docente[]) => {
+        const mapped: Profesor[] = docentes.map((doc) => ({
+          id: doc.id,
+          nombre: doc.nombre,
+          carrera: doc.carrera,
+          telefono: doc.telefono,
+          ramas: null,
+        }));
+        this.profesores.set(mapped);
+        this.profesoresCargando.set(false);
+      },
+      error: (err) => {
+        console.error('No fue posible cargar los docentes', err);
+        this.profesoresError.set('No fue posible cargar el listado de docentes.');
+        this.profesoresCargando.set(false);
+      },
+    });
+  }
+
+  private profesoresDistintosValidator = (group: FormGroup) => {
+    const p1 = group.get('prof1')?.value;
+    const p2 = group.get('prof2')?.value;
+    const p3 = group.get('prof3')?.value;
+    const arr = [p1, p2, p3].filter(Boolean);
+    return new Set(arr).size !== arr.length ? { profesoresDuplicados: true } : null;
+  };
+
+  private obtenerAlumnoIdActual(): number | null {
+    const perfil = this.currentUserService.getProfile();
+    if (!perfil?.id || perfil.rol !== 'alumno') {
+      return null;
+    }
+    return perfil.id;
+  }
+}

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -1,343 +1,87 @@
-
 <div class="card">
   <h2 class="ttl">Trabajo de Título</h2>
 
-  <div class="tabs">
-    <button *ngIf="tieneNivel('i')" [class.active]="tab() === 'i'" (click)="tab.set('i')">T. Título I</button>
-    <button *ngIf="tieneNivel('ii')" [class.active]="tab() === 'ii'" (click)="tab.set('ii')">T. Título II</button>
-    <button [class.active]="tab() === 'temas'" (click)="tab.set('temas')">Temas</button>
-    <button [class.active]="tab() === 'propuestas'" (click)="tab.set('propuestas')">Propuestas</button>
+  <ng-container *ngIf="nivelesDisponibles().length; else sinNiveles">
+    <div class="tabs">
+      <button *ngIf="tieneNivel('i')" [class.active]="nivelSeleccionado() === 'i'" (click)="seleccionarNivel('i')">
+        T. Título I
+      </button>
+      <button *ngIf="tieneNivel('ii')" [class.active]="nivelSeleccionado() === 'ii'" (click)="seleccionarNivel('ii')">
+        T. Título II
+      </button>
+      <a class="btn link" routerLink="/alumno/temas">Ver temas disponibles</a>
+    </div>
 
-  </div>
+    <p class="subtitle" *ngIf="nivelTitulo()">Tu progreso en {{ nivelTitulo() }}</p>
 
-
-  <ng-container [ngSwitch]="tab()">
-    <ng-container *ngSwitchCase="'temas'">
-      <div class="row-head">
-        <h3>Temas para Trabajo de título</h3>
-        <button class="btn primary" (click)="togglePostulacion(true)">
-          + Postular / Proponer tema
-        </button>
+    <ng-container *ngIf="resumenNivel() as resumen">
+      <div class="chips metrics">
+        <span class="chip highlight">Avance general: {{ resumen.avance }}%</span>
+        <span class="chip ghost">Entregas aprobadas: {{ resumen.aprobadas }} / {{ resumen.totales }}</span>
+        <span class="chip">Próximo hito: {{ resumen.proximoHito }}</span>
+        <span class="chip">Último feedback: {{ resumen.ultimoFeedback }}</span>
+        <span class="chip">Profesor guía: {{ resumen.profesorGuia }}</span>
       </div>
-      <p class="muted">Completa el formulario para solicitar o proponer un tema.</p>
-
-      <section class="mis-propuestas">
-        <p class="muted" *ngIf="propuestasCargando()">Actualizando el estado de tus propuestas…</p>
-        <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
-
-        <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
-          <ng-container *ngIf="propuestaDestacada() as propuestaPrincipal; else sinPropuestaDestacada">
-            <div class="propuesta-highlight">
-              <div class="highlight-head">
-                <span class="chip" [ngClass]="chipClasePropuesta(propuestaPrincipal.estado)">
-                  {{ etiquetaPropuestaDestacada(propuestaPrincipal) }}
-                </span>
-                <span class="chip ghost">Actualizada {{ propuestaPrincipal.updatedAt | date:'dd MMM yyyy' }}</span>
-              </div>
-              <h4>{{ propuestaPrincipal.titulo }}</h4>
-              <p class="muted">{{ propuestaPrincipal.descripcion }}</p>
-              <div class="chips">
-                <span class="chip">Rama: {{ propuestaPrincipal.rama }}</span>
-                <span class="chip ghost" *ngIf="propuestaPrincipal.docente">
-                  Docente guía: {{ propuestaPrincipal.docente.nombre }}
-                </span>
-              </div>
-              <p class="comentario" *ngIf="propuestaPrincipal.comentarioDecision">
-                Comentario del docente:
-                <span>{{ propuestaPrincipal.comentarioDecision }}</span>
-              </p>
-            </div>
-          </ng-container>
-        </ng-container>
-      </section>
-
-      <ng-template #sinPropuestaDestacada>
-        <p class="muted">Aún no tienes propuestas aceptadas ni pendientes.</p>
-      </ng-template>
-
-      <ng-container *ngIf="temasCargando(); else temasContenido">
-        <p class="muted" style="margin-top: 1rem">Cargando temas disponibles...</p>
-      </ng-container>
-
-      <ng-template #temasContenido>
-        <div class="err" *ngIf="temasError(); else temasLista">{{ temasError() }}</div>
-      </ng-template>
-
-      <ng-template #sinTemas>
-        <p class="muted" style="margin-top: 1rem">Aún no hay temas disponibles.</p>
-      </ng-template>
-
-      <ng-template #temasLista>
-        <div class="alert success" *ngIf="reservaMensaje()">{{ reservaMensaje() }}</div>
-        <div class="alert error" *ngIf="reservaError()">{{ reservaError() }}</div>
-        <ul class="list topics" *ngIf="temas().length; else sinTemas">
-          <li *ngFor="let tema of temas()">
-            <div class="grupo-info">
-              <div class="grupo-nombre">
-                {{ tema.titulo }}
-                <span class="badge">{{ tema.carrera }}</span>
-              </div>
-              <div class="grupo-alumnos">{{ tema.descripcion }}</div>
-              <div class="tema-autor" *ngIf="tema.creadoPor as autor">
-                <span class="tema-autor__icon" aria-hidden="true">👤</span>
-                <span>
-                  {{ autor.rol === 'docente' ? 'Profesor creador' : 'Creado por' }}:
-                  <strong class="tema-autor__nombre">{{ autor.nombre }}</strong>
-                  · {{ autor.rol | titlecase }}
-                  <ng-container *ngIf="autor.carrera"> — {{ autor.carrera }}</ng-container>
-                </span>
-              </div>
-              <div class="chips meta">
-                <span class="chip ghost">Cupos disp.: {{ tema.cuposDisponibles }} / {{ tema.cupos }}</span>
-                <span class="chip success" *ngIf="tema.tieneCupoPropio">Tu cupo reservado</span>
-              </div>
-              <div class="chips requisitos" *ngIf="tema.requisitos?.length">
-                <span class="chip" *ngFor="let req of tema.requisitos">{{ req }}</span>
-              </div>
-            </div>
-            <button
-              type="button"
-              class="btn primary sm"
-              [disabled]="!puedePedirTema(tema) || reservandoTemaId() === tema.id"
-              (click)="abrirConfirmacionTema(tema)"
-            >
-              {{ etiquetaPedirTema(tema) }}
-            </button>
-          </li>
-        </ul>
-      </ng-template>
     </ng-container>
-    <ng-container *ngSwitchCase="'propuestas'">
-      <section class="mis-propuestas">
-        <p class="muted" *ngIf="propuestasCargando()">Actualizando el estado de tus propuestas…</p>
-        <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
 
-        <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
-          <div class="propuestas-historial" *ngIf="propuestasEnHistorial().length; else sinPropuestas">
-            <h4>Historial de propuestas</h4>
-            <ul class="list propuestas">
-              <li *ngFor="let propuesta of propuestasEnHistorial()">
-                <div class="grupo-info">
-                  <div class="grupo-nombre">
-                    {{ propuesta.titulo }}
-                    <span class="badge propuesta" [ngClass]="estadoPropuestaClase(propuesta.estado)">
-                      {{ estadoPropuestaTexto[propuesta.estado] }}
-                    </span>
-                  </div>
-                  <div class="grupo-alumnos">{{ propuesta.objetivo }}</div>
-                  <p class="comentario" *ngIf="propuesta.comentarioDecision">
-                    Comentario: <span>{{ propuesta.comentarioDecision }}</span>
-                  </p>
-                  <div class="chips">
-                    <span class="chip ghost">Actualizada {{ propuesta.updatedAt | date:'dd MMM yyyy' }}</span>
-                    <span class="chip ghost" *ngIf="propuesta.docente">Docente: {{ propuesta.docente.nombre }}</span>
-                  </div>
-                </div>
-              </li>
-            </ul>
-          </div>
+    <div class="upload-card" *ngIf="entregaDestacada() as destacada; else sinDestacada">
+      <div class="upload-header">
+        <h3>{{ destacada.encabezado }}</h3>
+        <span class="badge" [ngClass]="destacada.estado">{{ destacada.estadoEtiqueta }}</span>
+      </div>
+      <p class="upload-title">{{ destacada.nombre }}</p>
+      <p class="muted">{{ destacada.descripcion }}</p>
+      <div class="chips">
+        <span class="chip">{{ destacada.fecha }}</span>
+        <span class="chip ghost" *ngIf="destacada.proximoPaso">Próximo paso: {{ destacada.proximoPaso }}</span>
+      </div>
+      <div class="upload-actions">
+        <button class="btn primary" routerLink="/alumno/entrega">Gestionar entregas</button>
+      </div>
+    </div>
 
-          <ng-template #sinPropuestas>
-            <p class="muted">Aún no envías propuestas personalizadas.</p>
-          </ng-template>
-        </ng-container>
-      </section>
-    </ng-container>
-    <ng-container *ngSwitchDefault>
-      <p class="subtitle">Tu progreso en {{ nivelTitulo() }}</p>
-
-      <ng-container *ngIf="resumenNivel() as resumen">
-        <div class="chips metrics">
-          <span class="chip highlight">Avance general: {{ resumen.avance }}%</span>
-          <span class="chip ghost">Entregas aprobadas: {{ resumen.aprobadas }} / {{ resumen.totales }}</span>
-          <span class="chip">Próximo hito: {{ resumen.proximoHito }}</span>
-          <span class="chip">Último feedback: {{ resumen.ultimoFeedback }}</span>
-          <span class="chip">Profesor guía: {{ resumen.profesorGuia }}</span>
-        </div>
-      </ng-container>
-
-      <div class="upload-card" *ngIf="entregaDestacada() as destacada; else sinDestacada">
-        <div class="upload-header">
-          <h3>{{ destacada.encabezado }}</h3>
-          <span class="badge" [ngClass]="destacada.estado">{{ destacada.estadoEtiqueta }}</span>
-        </div>
-        <p class="upload-title">{{ destacada.nombre }}</p>
-        <p class="muted">{{ destacada.descripcion }}</p>
-        <div class="chips">
-          <span class="chip">{{ destacada.fecha }}</span>
-          <span class="chip ghost" *ngIf="destacada.proximoPaso">Próximo paso: {{ destacada.proximoPaso }}</span>
-        </div>
+    <ng-template #sinDestacada>
+      <div class="upload-card empty">
+        <h3>Sin entregas destacadas</h3>
+        <p class="muted">Cuando registres avances verás aquí un resumen de tu próxima acción.</p>
         <div class="upload-actions">
-          <button class="btn primary" routerLink="/alumno/entrega">Gestionar entregas </button>
+          <a class="btn link" routerLink="/alumno/entrega">Ir a entregas</a>
         </div>
       </div>
+    </ng-template>
 
-      <ng-template #sinDestacada>
-        <div class="upload-card empty">
-          <h3>Sin entregas destacadas</h3>
-          <p class="muted">Cuando registres avances verás aquí un resumen de tu próxima acción.</p>
-          <div class="upload-actions">
-            <a class="btn link" routerLink="/alumno/entrega">Ir a entregas</a>
-          </div>
-        </div>
-      </ng-template>
+    <h3 class="section-title">Entregas e hitos recientes</h3>
 
-      <h3 class="section-title">Entregas e hitos recientes</h3>
-
-      <ng-container *ngIf="entregasPorNivel().length; else sinEntregas">
-        <ul class="list">
-          <li *ngFor="let item of entregasPorNivel()">
-            <div class="grupo-info">
-              <div class="grupo-nombre">
-                {{ item.nombre }}
-                <span class="badge" [ngClass]="item.estado">{{ estadoTexto[item.estado] }}</span>
-                <span class="badge soft">{{ item.badge }}</span>
-                <span *ngIf="item.alerta" class="alert-icon">{{ item.alerta }}</span>
-                <span *ngIf="item.estado === 'aprobado'" class="status-icon" aria-label="Aprobado">✓</span>
-              </div>
-              <div class="grupo-alumnos">{{ item.descripcion }}</div>
-              <div class="chips">
-                <span class="chip">{{ item.fecha }}</span>
-                <span class="chip ghost" *ngIf="item.proximoPaso">Próximo paso: {{ item.proximoPaso }}</span>
-              </div>
+    <ng-container *ngIf="entregasPorNivel().length; else sinEntregas">
+      <ul class="list">
+        <li *ngFor="let item of entregasPorNivel()">
+          <div class="grupo-info">
+            <div class="grupo-nombre">
+              {{ item.nombre }}
+              <span class="badge" [ngClass]="item.estado">{{ estadoTexto[item.estado] }}</span>
+              <span class="badge soft">{{ item.badge }}</span>
+              <span *ngIf="item.alerta" class="alert-icon">{{ item.alerta }}</span>
+              <span *ngIf="item.estado === 'aprobado'" class="status-icon" aria-label="Aprobado">✓</span>
             </div>
-          </li>
-        </ul>
-      </ng-container>
-
-      <ng-template #sinEntregas>
-        <p class="muted">Aún no tienes entregas registradas en {{ nivelTitulo() }}.</p>
-      </ng-template>
+            <div class="grupo-alumnos">{{ item.descripcion }}</div>
+            <div class="chips">
+              <span class="chip">{{ item.fecha }}</span>
+              <span class="chip ghost" *ngIf="item.proximoPaso">Próximo paso: {{ item.proximoPaso }}</span>
+            </div>
+          </div>
+        </li>
+      </ul>
     </ng-container>
+
+    <ng-template #sinEntregas>
+      <p class="muted">Aún no tienes entregas registradas en {{ nivelTitulo() }}.</p>
+    </ng-template>
   </ng-container>
 
-<!-- CORREGIDO: usa getter o bracket notation -->
-    <div class="backdrop" *ngIf="temaSeleccionado()" (click)="cerrarConfirmacionTema()"></div>
-    <div class="modal confirm-modal" *ngIf="temaSeleccionado() as temaEnConfirmacion" role="dialog" aria-modal="true">
-      <div class="modal-head">
-        <h4 class="ttl" style="margin: 0">Confirmar reserva</h4>
-        <button class="icon" (click)="cerrarConfirmacionTema()" aria-label="Cerrar">✕</button>
-      </div>
-      <div class="modal-body tema-confirmacion">
-        <div class="chips meta">
-          <span class="chip ghost">Cupos disponibles: {{ temaEnConfirmacion.cuposDisponibles }} / {{ temaEnConfirmacion.cupos }}</span>
-          <span class="chip ghost">Carrera: {{ temaEnConfirmacion.carrera }}</span>
-        </div>
-        <div>
-          <h5>{{ temaEnConfirmacion.titulo }}</h5>
-          <p class="descripcion">{{ temaEnConfirmacion.descripcion }}</p>
-        </div>
-        <div class="tema-confirmacion__autor">
-          <span aria-hidden="true">👤</span>
-          <span>
-            Profesor responsable:
-            <strong>{{ temaEnConfirmacion.creadoPor?.nombre || 'Por asignar' }}</strong>
-          </span>
-        </div>
-        <div class="tema-confirmacion__requisitos" *ngIf="temaEnConfirmacion.requisitos?.length; else sinRequisitos">
-          <h6>Requisitos del tema</h6>
-          <ul>
-            <li *ngFor="let requisito of temaEnConfirmacion.requisitos">{{ requisito }}</li>
-          </ul>
-        </div>
-        <ng-template #sinRequisitos>
-          <p class="muted" style="margin: 0">Este tema no especifica requisitos adicionales.</p>
-        </ng-template>
-        <p>¿Deseas continuar con la reserva?</p>
-      </div>
-      <div class="actions">
-        <button type="button" class="btn light" (click)="cerrarConfirmacionTema()">Cancelar</button>
-        <button
-          type="button"
-          class="btn primary"
-          [disabled]="reservandoTemaId() === temaEnConfirmacion.id"
-          (click)="confirmarReservaTema()"
-        >
-          {{ reservandoTemaId() === temaEnConfirmacion.id ? 'Reservando…' : 'Confirmar' }}
-        </button>
-      </div>
-    </div>
-
-    <div class="backdrop" *ngIf="showPostulacion()" (click)="togglePostulacion(false)"></div>
-        <div class="modal" *ngIf="showPostulacion()" role="dialog" aria-modal="true">
-        <div class="modal-head">
-        <h4 class="ttl" style="margin: 0">Solicitud de Tema</h4>
-        <button class="icon" (click)="togglePostulacion(false)" aria-label="Cerrar">✕</button>
-      </div>
-
-        <form [formGroup]="postulacionForm" (ngSubmit)="submitPostulacion()" class="grid" novalidate>
-          <div class="muted" *ngIf="profesoresCargando()">Cargando docentes disponibles...</div>
-          <div class="err" *ngIf="profesoresError()">{{ profesoresError() }}</div>
-          <div class="muted" *ngIf="!profesoresCargando() && !profesoresError() && !profesores().length">
-            Por ahora no hay docentes disponibles en el listado.
-          </div>
-          <div class="err" *ngIf="postulacionError()">{{ postulacionError() }}</div>
-
-        <div class="field full">
-          <label for="titulo">Nombre del tema <span class="req">*</span></label>
-          <input id="titulo" type="text" formControlName="titulo" />
-          <div class="err" *ngIf="hasError('titulo','required')">Obligatorio.</div>
-          <div class="err" *ngIf="hasError('titulo','maxlength')">Máx. 160 caracteres.</div>
-        </div>
-
-        <div class="field full">
-          <label for="objetivo">Objetivo <span class="req">*</span></label>
-          <input id="objetivo" type="text" formControlName="objetivo" />
-          <div class="err" *ngIf="hasError('objetivo','required')">Obligatorio.</div>
-          <div class="err" *ngIf="hasError('objetivo','maxlength')">Máx. 300 caracteres.</div>
-        </div>
-
-        <div class="field full">
-          <label for="descripcion">Breve descripción <span class="req">*</span></label>
-          <textarea id="descripcion" rows="5" formControlName="descripcion"></textarea>
-          <div class="err" *ngIf="hasError('descripcion','required')">Obligatorio.</div>
-          <div class="err" *ngIf="hasError('descripcion','maxlength')">Máx. 1200 caracteres.</div>
-        </div>
-
-        <div class="field">
-          <label for="rama">Rama de la carrera <span class="req">*</span></label>
-          <select id="rama" formControlName="rama">
-            <option value="" disabled>Selecciona una rama</option>
-            <option *ngFor="let r of ramas" [value]="r">{{ r }}</option>
-          </select>
-          <div class="err" *ngIf="hasError('rama','required')">Selecciona una rama.</div>
-        </div>
-
-        <div class="field">
-          <label for="prof1">Profesor guía (Preferencia 1) <span class="req">*</span></label>
-          <select id="prof1" formControlName="prof1">
-            <option value="" disabled>Selecciona</option>
-            <option *ngFor="let p of profesoresFiltrados()" [value]="p.id">{{ p.nombre }}</option>
-          </select>
-          <div class="err" *ngIf="hasError('prof1','required')">Selecciona una opción.</div>
-        </div>
-
-        <div class="field">
-          <label for="prof2">Profesor guía (Preferencia 2)</label>
-          <select id="prof2" formControlName="prof2">
-            <option value="">(Opcional)</option>
-            <option *ngFor="let p of profesoresFiltrados()" [value]="p.id">{{ p.nombre }}</option>
-          </select>
-        </div>
-
-        <div class="field">
-          <label for="prof3">Profesor guía (Preferencia 3)</label>
-          <select id="prof3" formControlName="prof3">
-            <option value="">(Opcional)</option>
-            <option *ngFor="let p of profesoresFiltrados()" [value]="p.id">{{ p.nombre }}</option>
-          </select>
-        </div>
-
-        <div class="field full" *ngIf="profesoresDuplicados">
-          <span class="err">Las preferencias no pueden repetir al mismo profesor.</span>
-        </div>
-
-        <div class="actions full">
-          <button type="button" class="btn light" (click)="togglePostulacion(false)">Cancelar</button>
-          <button type="submit" class="btn primary" [disabled]="enviandoPropuesta()">
-            {{ enviandoPropuesta() ? 'Enviando…' : 'Enviar postulación' }}
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
+  <ng-template #sinNiveles>
+    <p class="muted">
+      Tu plan de estudios no contempla trabajo de título. Puedes revisar los temas disponibles desde la sección
+      <a routerLink="/alumno/temas">Temas</a>.
+    </p>
+  </ng-template>
+</div>

--- a/frontend/src/app/features/docente/calendario/calendario.component.css
+++ b/frontend/src/app/features/docente/calendario/calendario.component.css
@@ -33,7 +33,7 @@
 .doc-title{
   text-align:center; font-weight:900; color:var(--doc-text); font-size:22px;
 }
-.doc-pill{
+.doc-pill{ 
   border:0; background:#e9f1ff; color:var(--doc-text);
   padding:8px 14px; font-weight:800; border-radius:20px; cursor:pointer;
   box-shadow:inset 0 0 0 1px #cfe3ff;
@@ -41,6 +41,15 @@
 .doc-pill:hover{ background:#deebff; }
 .doc-pill.muted{ background:#eef2f7; box-shadow:inset 0 0 0 1px #d9e2ef; }
 .doc-pill.primary{ background:var(--doc-primary); color:#fff; box-shadow:0 6px 16px rgba(25,118,210,.25); }
+.doc-pill[disabled]{
+  opacity:.6;
+  cursor:not-allowed;
+  box-shadow:inset 0 0 0 1px #d1d5db;
+}
+.doc-pill.primary[disabled]{
+  background:linear-gradient(135deg, #a7c8f3, #7ea8e1);
+  color:#f1f5fb;
+}
 .doc-divider{ height:2px; background:#d6e5ff; margin:8px 0 10px; border-radius:2px; }
 
 /* ===== Calendario grande (7 columnas) ===== */

--- a/frontend/src/app/features/docente/calendario/calendario.component.html
+++ b/frontend/src/app/features/docente/calendario/calendario.component.html
@@ -305,6 +305,12 @@
       </div>
 
       <div class="doc-modal-actions" style="margin-top:8px;">
+        <button type="button"
+                class="doc-pill primary"
+                (click)="exportResumenCsv()"
+                [disabled]="resumen().length === 0">
+          Exportar CSV
+        </button>
         <button type="button" class="doc-pill" (click)="closeResumen()">Cerrar</button>
       </div>
     </div>

--- a/frontend/src/app/features/docente/calendario/calendario.component.ts
+++ b/frontend/src/app/features/docente/calendario/calendario.component.ts
@@ -370,6 +370,57 @@ export class CalendarioComponent {
     return out;
   });
 
+  exportResumenCsv() {
+    const summary = this.resumen();
+    if (!summary.length || typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const lines: string[] = ['Fecha,Hora,Título,Lugar,Descripción'];
+    for (const day of summary) {
+      const dateLabel = this.toInputDate(day.date);
+      for (const ev of day.items) {
+        const row = [
+          this.csvCell(dateLabel),
+          this.csvCell(ev.hora),
+          this.csvCell(ev.titulo),
+          this.csvCell(ev.lugar),
+          this.csvCell(ev.descripcion)
+        ].join(',');
+        lines.push(row);
+      }
+    }
+
+    if (lines.length === 1) {
+      return;
+    }
+
+    const blob = new Blob([lines.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `resumen-reuniones-${this.timestamp()}.csv`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
+  private csvCell(value: string | undefined) {
+    const normalized = (value ?? '').replace(/\r?\n|\r/g, ' ').trim();
+    return `"${normalized.replace(/"/g, '""')}"`;
+  }
+
+  private timestamp() {
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, '0');
+    const dd = String(now.getDate()).padStart(2, '0');
+    const hh = String(now.getHours()).padStart(2, '0');
+    const min = String(now.getMinutes()).padStart(2, '0');
+    return `${yyyy}${mm}${dd}-${hh}${min}`;
+  }
+
   /* ===== Util ===== */
   private toInputDate(d: Date) {
     const yyyy = d.getFullYear();

--- a/frontend/src/app/features/docente/layout/docente-layout.component.ts
+++ b/frontend/src/app/features/docente/layout/docente-layout.component.ts
@@ -27,6 +27,7 @@ export class DocenteLayoutComponent implements OnDestroy {
     { route: 'bandeja', label: 'Bandeja de Entrada', icon: 'assets/Bandeja_entrada.png', alt: 'Bandeja de entrada' },
     { route: 'dashboard', label: 'Panel Docente', icon: 'assets/Inicio.png', alt: 'Panel docente' },
     { route: 'trabajo', label: 'Trabajo de Título', icon: 'assets/Procesos.png', alt: 'Trabajo de título' },
+    { route: 'temas', label: 'Temas', icon: 'assets/Reportes.png', alt: 'Temas de trabajo de título' },
     { route: 'evaluaciones', label: 'Evaluaciones', icon: 'assets/Evaluaciones.png', alt: 'Evaluaciones' },
     { route: 'calendario', label: 'Calendario', icon: 'assets/Calendario.png', alt: 'Calendario' },
     { route: 'perfil', label: 'Perfil', icon: 'assets/Perfil.png', alt: 'Perfil' },

--- a/frontend/src/app/features/docente/temas/docente-temas.component.css
+++ b/frontend/src/app/features/docente/temas/docente-temas.component.css
@@ -1,0 +1,368 @@
+/* Título y contenedor */
+.ttl { color:#1a3e6a; margin-bottom:10px; font-weight:800; }
+.card {
+  background:#fff; border:1px solid #e9eef6; border-radius:12px;
+  padding:14px; box-shadow:0 8px 28px rgba(0,0,0,.06); margin-bottom:12px;
+}
+
+/* Tabs */
+.tabs { display:flex; gap:18px; align-items:center; padding:0 6px 8px; }
+.tabs button { background:none; border:0; color:#4b5563; font-weight:700; cursor:pointer; padding:6px 0; }
+.tabs button.active { color:#0590a8; border-bottom:2px solid #0590a8; }
+
+.row-head {
+  display:flex; align-items:center; justify-content:space-between;
+  gap:12px; margin:8px 0 12px;
+}
+.muted { color:#6b7280; }
+
+/* Botones */
+.btn { border:0; border-radius:8px; padding:8px 14px; font-weight:800; cursor:pointer; }
+.btn.primary { background:#1a73e8; color:#fff; }
+.btn.outline { background:#eef5ff; color:#1a56db; border:1px solid #c7d8ff; }
+.btn.outline:hover { background:#dbe8ff; }
+.btn.danger { background:#d32f2f; color:#fff; font-weight: bold; }
+.btn.light { background:#eef2f7; color:#1f2937; }
+.btn.sm { padding:4px 10px; font-size:.9rem; }
+
+/* Chips */
+.chip { border-radius:999px; padding:2px 8px; font-weight:800; font-size:.8rem; }
+.chip-ok { background:#e7f9ef; color:#0a7a3a; }
+.chip-bad { background:#fde8e8; color:#9a1b1b; }
+.chip-warn { background:#fff7ed; color:#9a3412; }
+.chip.ghost { background:#f4f7fb; color:#1a3e6a; border:1px solid #dbe3ee; }
+
+.badge {
+  display:inline-flex;
+  align-items:center;
+  padding:4px 10px;
+  border-radius:999px;
+  background:#e8fff6;
+  border:1px solid #cfe2ff;
+  color:#1a3e6a;
+  font-weight:700;
+  font-size:.85rem;
+}
+.chips.meta {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  align-items:center;
+}
+/* ===== Modal base ===== */
+.backdrop { position:fixed; inset:0; background:rgba(0,0,0,.45); z-index:900; }
+.modal {
+  position:fixed; top:50%; left:50%; transform:translate(-50%,-50%);
+  background:#fff; width:min(92vw,1100px); max-height:90vh;
+  border-radius:12px; box-shadow:0 10px 30px rgba(0,0,0,.28); z-index:901;
+  display:flex; flex-direction:column;
+  overflow:hidden;
+  padding-bottom:18px;
+}
+.modal.narrow { width:min(92vw, 720px); }
+.tema-detalle-modal { width:min(92vw, 780px); }
+.tema-detalle__body {
+  padding:20px 24px;
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+  max-height:calc(90vh - 120px);
+  overflow-y:auto;
+  box-sizing:border-box;
+}
+.tema-detalle__descripcion h4 {
+  margin:0 0 4px;
+  color:#1a3e6a;
+}
+.tema-detalle__descripcion p {
+  margin:0;
+  color:#1f2937;
+}
+.tema-detalle__autor {
+  display:flex;
+  gap:12px;
+  align-items:center;
+  background:#f5f9ff;
+  border:1px solid #dbe3ee;
+  border-radius:10px;
+  padding:12px 14px;
+}
+.tema-detalle__autor span[aria-hidden="true"] {
+  font-size:1.4rem;
+}
+.tema-detalle__autor-nombre {
+  margin:0;
+  font-weight:700;
+  color:#1a3e6a;
+}
+.tema-detalle__seccion h5 {
+  margin:0 0 6px;
+  color:#1a3e6a;
+}
+.tema-detalle__seccion ul {
+  margin:0;
+  padding-left:18px;
+  color:#1f2937;
+}
+.tema-detalle__inscritos {
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.tema-detalle__inscritos li {
+  border:1px solid #e2e8f0;
+  border-radius:12px;
+  padding:12px 14px;
+  background:#ffffff;
+  box-shadow:0 1px 4px rgba(0,0,0,.04);
+}
+.inscrito-nombre {
+  font-weight:700;
+  color:#1a3e6a;
+}
+.inscrito-meta,
+.inscrito-contacto,
+.inscrito-reserva {
+  font-size:.9rem;
+  color:#4b5563;
+  margin-top:4px;
+}
+.inscrito-contacto span + span {
+  margin-left:4px;
+}
+.inscrito-meta span + span {
+  margin-left:4px;
+}
+.modal-head {
+  display:flex; justify-content:space-between; align-items:center;
+  padding:16px 18px; border-bottom:1px solid #e9eef6; background:#f8fbff;
+}
+.modal-head .ttl { margin:0; }
+.icon { background:none; border:0; font-size:1.2rem; cursor:pointer; }
+
+/* ===== Formulario en modal ===== */
+.modal form.grid {
+  padding:20px 28px 24px;
+  display:grid;
+  grid-template-columns: 1fr 1fr;
+  gap:20px 22px;
+  max-height: calc(90vh - 84px);
+  overflow-y:auto;
+  overflow-x:hidden;
+  scrollbar-gutter: stable both-edges;
+  box-sizing:border-box;
+}
+.field { display:flex; flex-direction:column; gap:8px; }
+.field.full { grid-column:1 / -1; }
+.field label { font-weight:700; color:#374151; }
+.req { color:#dc2626; margin-left:4px; }
+
+input[type="text"],
+input[type="number"],
+textarea,
+select {
+  width:100%;
+  min-width:0;
+  box-sizing:border-box;
+  border:1px solid #dbe3ee;
+  border-radius:10px;
+  padding:10px 12px;
+  font:inherit;
+  outline:none;
+  background:#fff;
+}
+.readonly {
+  width:100%;
+  border:1px dashed #e0e7f1;
+  border-radius:10px;
+  padding:10px 12px;
+  background:#fbfdff;
+}
+textarea { min-height:130px; resize:vertical; }
+
+input[type="text"]:focus,
+input[type="number"]:focus,
+textarea:focus,
+select:focus {
+  border-color:#9cc2ff;
+  box-shadow:0 0 0 3px rgba(25,118,210,.12);
+}
+
+.err { color:#b91c1c; font-size:.85rem; }
+
+.actions { display:flex; gap:12px; justify-content:center; align-items:center; }
+.actions.full { grid-column:1 / -1; }
+
+/* ===== Tabla propuestas ===== */
+.tabla { border:1px solid #e9eef6; border-radius:10px; overflow:hidden; margin:16px 24px 14px; }
+.tabla .head {
+  display:grid; grid-template-columns:1.1fr 1.4fr 1fr .8fr .7fr .6fr;
+  background:#f7fbff; font-weight:800; color:#1a3e6a; padding:10px 12px;
+}
+.fila {
+  display:grid; grid-template-columns:1.1fr 1.4fr 1fr .8fr .7fr .6fr;
+  padding:10px 12px; align-items:center; border-bottom:1px solid #eef2f7;
+}
+.fila:nth-child(even) { background:#fafbfd; }
+
+.detalle {
+  border:1px solid #e9eef6; border-radius:10px; padding:16px 24px;
+  background:#fbfdff; margin:16px 24px 20px;
+}
+.detalle h4 { margin:0 0 6px; color:#1a3e6a; }
+.form { display:flex; flex-direction:column; gap:10px; }
+.form textarea { min-height:110px; }
+
+/* === TARJETAS DE GRUPOS ASIGNADOS === */
+.grupos-container {
+  display:flex; flex-direction:column; gap:14px; margin-top:10px;
+}
+.grupo-card {
+  background:#fff; border:1px solid #e9eef6; border-radius:12px;
+  box-shadow:0 2px 6px rgba(0,0,0,.06);
+  padding:16px 18px; display:flex; justify-content:space-between; align-items:center;
+  transition:transform .15s ease, box-shadow .15s ease;
+}
+.grupo-card:hover { transform:translateY(-2px); box-shadow:0 4px 10px rgba(0,0,0,.08); }
+.grupo-info { display:flex; flex-direction:column; gap:4px; }
+.grupo-nombre { font-weight:800; color:#1a3e6a; font-size:1rem; }
+.grupo-integrantes { color:#4b5563; font-size:.95rem; }
+.btn-ver {
+  background:#1a73e8; color:#fff; border:none; border-radius:8px;
+  padding:6px 14px; font-weight:700; cursor:pointer; transition:background .2s;
+}
+.btn-ver:hover { background:#155ac9; }
+.grupo-actions { display:flex; align-items:center; gap:10px; }
+
+/* Chip estado grupo */
+.chip-status {
+  display:inline-flex; align-items:center; gap:6px;
+  padding:4px 10px; border-radius:999px; font-weight:800; font-size:.85rem; line-height:1;
+  border:1px solid transparent;
+}
+.chip-pend { background:#fff7ed; color:#9a3412; border-color:#fde2c6; }
+.chip-rev  { background:#eef2ff; color:#3730a3; border-color:#d7dcff; }
+.chip-ok   { background:#e7f9ef; color:#0a7a3a; border-color:#c8f0da; }
+.chip-done { background:#ecfeff; color:#036672; border-color:#c9f7fb; }
+
+/* === ENTREGAS DEL GRUPO === */
+.entregas-grid { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+.sec { color:#1a3e6a; margin:6px 0 10px; }
+.hit-card {
+  background:#fff; border:1px solid #e9eef6; border-radius:12px;
+  padding:14px 16px; box-shadow:0 2px 6px rgba(0,0,0,.06); margin-bottom:12px;
+}
+.hit-head { display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:6px; }
+.hit-titulo { font-weight:800; color:#1a3e6a; }
+.hit-descr, .hit-meta { margin:4px 0 8px; }
+.hit-actions { display:flex; gap:10px; }
+.hit-resumen { margin-top:10px; border-top:1px dashed #e5edf7; padding-top:10px; color:#1f2937; }
+
+/* ===== Filtros ===== */
+.filtros-bar {
+  display:flex; gap:12px; align-items:center;
+  background:#f9fbfe; border:1px solid #e9eef6; border-radius:10px;
+  padding:10px 16px; margin-bottom:16px;
+}
+.filtros-bar select, .filtros-bar input {
+  padding:8px 12px; border:1px solid #dbe3ee; border-radius:8px;
+  font-size:.95rem; background:#fff; color:#1f2937;
+}
+.filtros-bar input { flex:1; }
+
+/* Responsive */
+@media (max-width: 860px) {
+  .modal form.grid { grid-template-columns:1fr; padding:18px; }
+  .tabla .head, .fila { grid-template-columns:1.2fr 1.6fr 1fr .8fr .8fr .7fr; }
+  .grupo-card { flex-direction:column; align-items:flex-start; gap:10px; }
+  .btn-ver { align-self:flex-end; }
+  .entregas-grid { grid-template-columns:1fr; }
+  .tema-detalle-modal { width:min(92vw, 95vw); }
+}
+
+/* === Temas disponibles === */
+.temas-list {
+  list-style:none;
+  margin:16px 0 0;
+  padding:0;
+  display:grid;
+  gap:16px;
+}
+
+.temas-item {
+  background:#fff;
+  border:1px solid #e1e7f0;
+  border-radius:14px;
+  padding:18px 20px;
+  box-shadow:0 8px 24px rgba(15,23,42,.08);
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+  transition:transform .2s ease, box-shadow .2s ease;
+}
+
+.temas-item__header {
+  display:flex;
+  justify-content:space-between;
+  gap:16px;
+  align-items:flex-start;
+}
+
+.temas-item__title {
+  margin:0;
+  color:#1a3e6a;
+  font-size:1.05rem;
+  font-weight:700;
+}
+
+.temas-item__objetivo {
+  margin:6px 0 0;
+  color:#4b5563;
+  line-height:1.45;
+}
+
+.temas-item__creator {
+  margin-top:10px;
+  display:flex;
+  align-items:center;
+  gap:10px;
+}
+
+.temas-item__creator-label {
+  font-size:0.85rem;
+  color:#1f2937;
+  font-weight:600;
+}
+
+.temas-item__creator-icon {
+  font-size:18px;
+}
+
+.temas-item__creator-name { color:#1a3e6a; font-weight:700; }
+
+.temas-item__creator-meta {
+  font-size:0.8rem;
+  color:#6b7280;
+}
+
+.temas-item__meta {
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.temas-item__actions {
+  display:flex;
+  justify-content:flex-end;
+}
+
+.temas-item:hover { box-shadow:0 12px 28px rgba(15,23,42,.12); transform:translateY(-2px); }
+
+@media (max-width: 640px) {
+  .temas-item { padding:16px; }
+  .temas-item__header { flex-direction:column; align-items:flex-start; }
+  .temas-item__actions { justify-content:flex-start; }
+}

--- a/frontend/src/app/features/docente/temas/docente-temas.component.html
+++ b/frontend/src/app/features/docente/temas/docente-temas.component.html
@@ -1,0 +1,235 @@
+<h2 class="ttl">Temas de Trabajo de Título</h2>
+
+<div class="row-head">
+  <h3>Temas disponibles</h3>
+  <div class="actions">
+    <button type="button" class="btn outline" (click)="togglePropuestasModal(true)">📄 Ver propuestas</button>
+    <button type="button" class="btn primary" (click)="abrirModalTema()">+ Agregar tema</button>
+  </div>
+</div>
+
+<p class="muted" *ngIf="temasCargando">Cargando temas publicados...</p>
+<div class="err" *ngIf="temasError">{{ temasError }}</div>
+
+<ng-container *ngIf="!temasCargando && !temasError">
+  <ng-container *ngIf="temas.length; else sinTemas">
+    <ul class="temas-list">
+      <li *ngFor="let tema of temas" class="temas-item">
+        <div class="temas-item__header">
+          <div>
+            <h4 class="temas-item__title">{{ tema.titulo }}</h4>
+            <p class="temas-item__objetivo">{{ tema.objetivo }}</p>
+            <div class="temas-item__creator" *ngIf="tema.creadoPor as autor">
+              <span class="temas-item__creator-icon" aria-hidden="true">👤</span>
+              <div>
+                <div class="temas-item__creator-label">
+                  {{ autor.rol === 'docente' ? 'Profesor creador' : 'Creado por' }}:
+                  <span class="temas-item__creator-name">{{ autor.nombre }}</span>
+                </div>
+                <div class="temas-item__creator-meta">
+                  {{ autor.rol | titlecase }}
+                  <ng-container *ngIf="autor.carrera"> · {{ autor.carrera }}</ng-container>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="temas-item__meta">
+          <span class="chip ghost">Cupos: {{ tema.cuposDisponibles }} / {{ tema.cupos }}</span>
+          <span class="chip ghost" *ngIf="tema.fecha">Fecha publicación: {{ tema.fecha | date:'shortDate' }}</span>
+          <span class="chip ghost">Reservas confirmadas: {{ tema.inscripcionesActivas.length }}</span>
+          <span class="badge">{{ tema.rama }}</span>
+        </div>
+
+        <div class="temas-item__actions">
+          <button class="btn light" type="button" (click)="verDetalleTema(tema)">Ver detalle</button>
+          <button class="btn danger" type="button" (click)="eliminarTema(tema)">Eliminar</button>
+        </div>
+      </li>
+    </ul>
+  </ng-container>
+</ng-container>
+
+<ng-template #sinTemas>
+  <p class="muted">No hay temas disponibles por ahora.</p>
+</ng-template>
+
+<div class="backdrop" *ngIf="showDetalleTema" (click)="cerrarDetalleTema()"></div>
+<div class="modal tema-detalle-modal" *ngIf="showDetalleTema" role="dialog" aria-modal="true">
+  <div class="modal-head">
+    <h4 class="ttl" style="margin:0">Detalle del tema</h4>
+    <button type="button" class="icon" (click)="cerrarDetalleTema()">✕</button>
+  </div>
+
+  <div class="tema-detalle__body">
+    <div class="muted" *ngIf="temaDetalleCargando">Cargando información del tema…</div>
+    <div class="err" *ngIf="temaDetalleError">{{ temaDetalleError }}</div>
+
+    <ng-container *ngIf="!temaDetalleCargando && !temaDetalleError && temaDetalle as detalle">
+      <div class="chips meta">
+        <span class="chip ghost">Cupos disponibles: {{ detalle.cuposDisponibles }} / {{ detalle.cupos }}</span>
+        <span class="chip ghost">Carrera: {{ detalle.carrera }}</span>
+        <span class="chip ghost" *ngIf="detalle.creadoEn">Creado: {{ detalle.creadoEn | date:'shortDate' }}</span>
+      </div>
+
+      <div class="tema-detalle__descripcion">
+        <h4>{{ detalle.titulo }}</h4>
+        <p>{{ detalle.descripcion }}</p>
+      </div>
+
+      <div class="tema-detalle__autor" *ngIf="detalle.creadoPor as autor">
+        <span aria-hidden="true">👤</span>
+        <div>
+          <p class="tema-detalle__autor-nombre">{{ autor.nombre }}</p>
+          <p class="muted">
+            {{ autor.rol | titlecase }}
+            <ng-container *ngIf="autor.carrera"> · {{ autor.carrera }}</ng-container>
+          </p>
+        </div>
+      </div>
+
+      <section class="tema-detalle__seccion">
+        <h5>Requisitos del tema</h5>
+        <ng-container *ngIf="detalle.requisitos.length; else sinRequisitosDoc">
+          <ul>
+            <li *ngFor="let requisito of detalle.requisitos">{{ requisito }}</li>
+          </ul>
+        </ng-container>
+        <ng-template #sinRequisitosDoc>
+          <p class="muted">Este tema no especifica requisitos adicionales.</p>
+        </ng-template>
+      </section>
+
+      <section class="tema-detalle__seccion">
+        <h5>Alumnos con reserva confirmada</h5>
+        <ng-container *ngIf="detalle.inscripciones.length; else sinInscritos">
+          <ul class="tema-detalle__inscritos">
+            <li *ngFor="let alumno of detalle.inscripciones">
+              <div class="inscrito-nombre">{{ alumno.nombre }}</div>
+              <div class="inscrito-meta">
+                <span>{{ alumno.carrera || 'Carrera no registrada' }}</span>
+                <span *ngIf="alumno.rut"> · RUT: {{ alumno.rut }}</span>
+              </div>
+              <div class="inscrito-contacto">
+                <span>Correo: {{ alumno.correo }}</span>
+                <span *ngIf="alumno.telefono"> · Teléfono: {{ alumno.telefono }}</span>
+              </div>
+              <div class="inscrito-reserva muted">Reservado el {{ alumno.reservadoEn | date:'short' }}</div>
+            </li>
+          </ul>
+        </ng-container>
+        <ng-template #sinInscritos>
+          <p class="muted">Aún no hay alumnos inscritos en este tema.</p>
+        </ng-template>
+      </section>
+    </ng-container>
+  </div>
+
+  <div class="actions" style="padding:0 24px 12px;">
+    <button type="button" class="btn light" (click)="cerrarDetalleTema()">Cerrar</button>
+  </div>
+</div>
+
+<div class="backdrop" *ngIf="showPropuestasModal" (click)="togglePropuestasModal(false)"></div>
+<div class="modal" *ngIf="showPropuestasModal" role="dialog" aria-modal="true">
+  <div class="modal-head">
+    <h4 class="ttl" style="margin:0">Propuestas de Trabajo de Título</h4>
+    <button type="button" class="icon" (click)="togglePropuestasModal(false)">✕</button>
+  </div>
+
+  <div class="muted" *ngIf="propuestasCargando">Cargando propuestas...</div>
+  <div class="err" *ngIf="propuestasError">{{ propuestasError }}</div>
+  <p class="muted" *ngIf="!propuestasCargando && !propuestasError && !propuestas.length">No hay propuestas registradas por ahora.</p>
+
+  <div class="tabla" *ngIf="!propuestasCargando && propuestas.length">
+    <div class="head">
+      <span>Alumno</span><span>Tema</span><span>Rama</span><span>Fecha</span><span>Estado</span><span></span>
+    </div>
+    <div *ngFor="let p of propuestas">
+      <div class="fila">
+        <div>{{ p.alumno?.nombre || 'Sin registro' }}</div>
+        <div>{{ p.titulo }}</div>
+        <div>{{ p.rama }}</div>
+        <div>{{ p.createdAt | date:'shortDate' }}</div>
+        <div>
+          <span class="chip"
+            [class.chip-ok]="p.estado==='aceptada'"
+            [class.chip-bad]="p.estado==='rechazada'"
+            [class.chip-warn]="p.estado==='pendiente'">{{ p.estado | titlecase }}</span>
+        </div>
+        <div><button class="btn sm" type="button" (click)="seleccionarPropuesta(p)">Revisar</button></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="detalle" *ngIf="propuestaSeleccionada as sel">
+    <h4>{{ sel.titulo }}</h4>
+    <p><b>Alumno:</b> {{ sel.alumno?.nombre || 'Sin registro' }}</p>
+    <p class="muted"><b>Rama:</b> {{ sel.rama }} — <b>Creada:</b> {{ sel.createdAt | date:'short' }}</p>
+    <p><b>Objetivo:</b> {{ sel.objetivo }}</p>
+    <p><b>Descripción:</b> {{ sel.descripcion }}</p>
+    <p *ngIf="sel.comentarioDecision" class="muted">Último comentario registrado: {{ sel.comentarioDecision }}</p>
+
+    <div class="form">
+      <label for="comentario">Comentario</label>
+      <textarea id="comentario" [(ngModel)]="comentarioDecision" placeholder="Fundamente su decisión..."></textarea>
+      <div class="actions">
+        <button class="btn primary" type="button" (click)="aceptarPropuesta()" [disabled]="!comentarioDecision || decisionEnCurso">Aceptar</button>
+        <button class="btn danger" type="button" (click)="rechazarPropuesta()" [disabled]="!comentarioDecision || decisionEnCurso">Rechazar</button>
+      </div>
+      <p class="muted" *ngIf="decisionEnCurso">Guardando decisión...</p>
+    </div>
+  </div>
+</div>
+
+<div class="backdrop" *ngIf="showModalTema" (click)="cerrarModalTema()"></div>
+<div class="modal narrow" *ngIf="showModalTema" role="dialog" aria-modal="true">
+  <div class="modal-head">
+    <h4 class="ttl" style="margin:0">Nuevo tema</h4>
+    <button type="button" class="icon" (click)="cerrarModalTema()">✕</button>
+  </div>
+
+  <form class="grid" (ngSubmit)="guardarTema()" novalidate>
+    <div class="field">
+      <label>Nombre del tema <span class="req">*</span></label>
+      <input type="text" [(ngModel)]="nuevoTema.titulo" name="titulo" required />
+    </div>
+
+    <div class="field">
+      <label>Objetivo <span class="req">*</span></label>
+      <input type="text" [(ngModel)]="nuevoTema.objetivo" name="objetivo" required />
+    </div>
+
+    <div class="field full">
+      <label>Breve descripción <span class="req">*</span></label>
+      <textarea [(ngModel)]="nuevoTema.descripcion" name="descripcion" required></textarea>
+    </div>
+
+    <div class="field">
+      <label>Rama de la carrera <span class="req">*</span></label>
+      <select [(ngModel)]="nuevoTema.rama" name="rama" required>
+        <option value="">Selecciona una rama</option>
+        <option *ngFor="let r of ramas" [value]="r">{{ r }}</option>
+      </select>
+      <div class="err" *ngIf="!nuevoTema.rama">Obligatorio.</div>
+    </div>
+
+    <div class="field">
+      <label>Cupos</label>
+      <input type="number" [(ngModel)]="nuevoTema.cupos" name="cupos" min="1" />
+    </div>
+
+    <div class="field full">
+      <label>Requisitos (separados por coma)</label>
+      <input type="text" [(ngModel)]="nuevoTema.requisitos" name="requisitos" placeholder="Ej: Linux, Git, Metodologías ágiles" />
+    </div>
+
+    <div class="err" *ngIf="enviarTemaError">{{ enviarTemaError }}</div>
+
+    <div class="actions full">
+      <button type="button" class="btn light" (click)="cerrarModalTema()">Cancelar</button>
+      <button type="submit" class="btn primary" [disabled]="enviarTema">{{ enviarTema ? 'Guardando…' : 'Guardar tema' }}</button>
+    </div>
+  </form>
+</div>

--- a/frontend/src/app/features/docente/temas/docente-temas.component.ts
+++ b/frontend/src/app/features/docente/temas/docente-temas.component.ts
@@ -1,0 +1,403 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { finalize } from 'rxjs';
+
+import { TemaService, TemaDisponible as TemaAPI, CrearTemaPayload, TemaInscripcionActiva } from '../trabajolist/tema.service';
+import { PropuestaService, Propuesta } from '../../../shared/services/propuesta.service';
+import { CurrentUserService } from '../../../shared/services/current-user.service';
+
+type Rama = 'Empresa' | 'Desarrollo de software' | 'Investigación' | 'Artículo' | 'I+D' | 'Otro';
+
+type TemaCreator = {
+  nombre: string;
+  rol: string;
+  carrera: string | null;
+};
+
+type TemaDisponible = {
+  id?: number;
+  titulo: string;
+  objetivo: string;
+  descripcion: string;
+  rama: string;
+  cupos: number;
+  cuposDisponibles: number;
+  requisitos: string;
+  fecha: Date | null;
+  creadoPor: TemaCreator | null;
+  inscripcionesActivas: TemaInscripcionActiva[];
+};
+
+type TemaDetalleInscripcion = {
+  id: number;
+  nombre: string;
+  correo: string;
+  carrera: string | null;
+  rut: string | null;
+  telefono: string | null;
+  reservadoEn: Date;
+};
+
+type TemaDetalleDocente = {
+  id: number;
+  titulo: string;
+  descripcion: string;
+  carrera: string;
+  cupos: number;
+  cuposDisponibles: number;
+  requisitos: string[];
+  creadoPor: TemaCreator | null;
+  inscripciones: TemaDetalleInscripcion[];
+  creadoEn: Date | null;
+};
+
+@Component({
+  selector: 'docente-temas',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './docente-temas.component.html',
+  styleUrls: ['./docente-temas.component.css'],
+})
+export class DocenteTemasComponent implements OnInit {
+  readonly ramas: Rama[] = ['Empresa', 'Desarrollo de software', 'Investigación', 'Artículo', 'I+D', 'Otro'];
+
+  temas: TemaDisponible[] = [];
+  temasCargando = false;
+  temasError: string | null = null;
+
+  showModalTema = false;
+  enviarTema = false;
+  enviarTemaError: string | null = null;
+
+  nuevoTema: Partial<TemaDisponible> = {
+    titulo: '',
+    objetivo: '',
+    descripcion: '',
+    rama: '',
+    cupos: 1,
+    requisitos: '',
+    inscripcionesActivas: [],
+  };
+
+  showDetalleTema = false;
+  temaDetalle: TemaDetalleDocente | null = null;
+  temaDetalleCargando = false;
+  temaDetalleError: string | null = null;
+
+  showPropuestasModal = false;
+  propuestaSeleccionada: Propuesta | null = null;
+  comentarioDecision = '';
+  propuestas: Propuesta[] = [];
+  propuestasCargando = false;
+  propuestasError: string | null = null;
+  private propuestasCargadas = false;
+  decisionEnCurso = false;
+
+  constructor(
+    private readonly temaService: TemaService,
+    private readonly propuestaService: PropuestaService,
+    private readonly currentUserService: CurrentUserService,
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarTemas();
+  }
+
+  abrirModalTema() {
+    this.showModalTema = true;
+    this.enviarTemaError = null;
+  }
+
+  cerrarModalTema() {
+    if (this.enviarTema) {
+      return;
+    }
+    this.showModalTema = false;
+    this.nuevoTema = {
+      titulo: '',
+      objetivo: '',
+      descripcion: '',
+      rama: '',
+      cupos: 1,
+      requisitos: '',
+      inscripcionesActivas: [],
+    };
+    this.enviarTema = false;
+    this.enviarTemaError = null;
+  }
+
+  guardarTema() {
+    if (!this.nuevoTema.titulo || !this.nuevoTema.descripcion || !this.nuevoTema.rama) {
+      return;
+    }
+
+    const requisitosArray = (this.nuevoTema.requisitos ?? '')
+      .toString()
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const payload: CrearTemaPayload = {
+      titulo: (this.nuevoTema.titulo ?? '').trim(),
+      carrera: (this.nuevoTema.rama ?? '').trim(),
+      descripcion: (this.nuevoTema.descripcion ?? '').trim(),
+      requisitos: requisitosArray,
+      cupos: Number(this.nuevoTema.cupos ?? 1),
+      inscripcionesActivas: [],
+    };
+
+    const perfil = this.currentUserService.getProfile();
+    if (perfil?.id) {
+      payload.created_by = perfil.id;
+    }
+
+    const autorActual = perfil
+      ? {
+          nombre: perfil.nombre,
+          rol: perfil.rol,
+          carrera: perfil.carrera ?? null,
+        }
+      : null;
+
+    this.enviarTema = true;
+    this.enviarTemaError = null;
+
+    this.temaService
+      .crearTema(payload)
+      .pipe(finalize(() => (this.enviarTema = false)))
+      .subscribe({
+        next: (temaCreado: TemaAPI) => {
+          const temaUI: TemaDisponible = {
+            id: temaCreado.id,
+            titulo: temaCreado.titulo,
+            objetivo: temaCreado.requisitos?.[0] ?? temaCreado.descripcion,
+            descripcion: temaCreado.descripcion,
+            rama: temaCreado.carrera,
+            cupos: temaCreado.cupos,
+            cuposDisponibles: temaCreado.cuposDisponibles,
+            requisitos: (temaCreado.requisitos?.join(', ') ?? ''),
+            fecha: temaCreado.created_at ? new Date(temaCreado.created_at) : new Date(),
+            creadoPor: temaCreado.creadoPor ?? autorActual ?? null,
+            inscripcionesActivas: temaCreado.inscripcionesActivas ?? [],
+          };
+          this.temas = [temaUI, ...this.temas];
+          this.cerrarModalTema();
+        },
+        error: () => {
+          this.enviarTemaError = 'No se pudo guardar el tema. Inténtalo nuevamente.';
+        },
+      });
+  }
+
+  eliminarTema(tema: TemaDisponible) {
+    if (!tema.id) {
+      this.temas = this.temas.filter((t) => t !== tema);
+      return;
+    }
+
+    const confirmado = confirm(`¿Está seguro de eliminar el tema "${tema.titulo}"? Esta acción no se puede deshacer.`);
+    if (!confirmado) {
+      return;
+    }
+
+    this.temaService.eliminarTema(tema.id).subscribe({
+      next: () => {
+        this.temas = this.temas.filter((t) => t.id !== tema.id);
+      },
+      error: () => {
+        alert('No se pudo eliminar el tema. Inténtalo nuevamente.');
+      },
+    });
+  }
+
+  verDetalleTema(tema: TemaDisponible) {
+    if (!tema.id) {
+      return;
+    }
+
+    this.showDetalleTema = true;
+    this.temaDetalleError = null;
+    this.temaDetalleCargando = true;
+    this.temaDetalle = {
+      id: tema.id,
+      titulo: tema.titulo,
+      descripcion: tema.descripcion,
+      carrera: tema.rama,
+      cupos: tema.cupos,
+      cuposDisponibles: tema.cuposDisponibles,
+      requisitos: [],
+      creadoPor: tema.creadoPor,
+      inscripciones: [],
+      creadoEn: tema.fecha ?? null,
+    };
+
+    const perfil = this.currentUserService.getProfile();
+    const opciones = perfil?.id != null ? { usuarioId: perfil.id } : undefined;
+
+    this.temaService.obtenerTema(tema.id, opciones).subscribe({
+      next: (temaApi) => {
+        this.temaDetalle = {
+          id: temaApi.id,
+          titulo: temaApi.titulo,
+          descripcion: temaApi.descripcion,
+          carrera: temaApi.carrera,
+          cupos: temaApi.cupos,
+          cuposDisponibles: temaApi.cuposDisponibles,
+          requisitos: temaApi.requisitos ?? [],
+          creadoPor: temaApi.creadoPor ?? null,
+          inscripciones: (temaApi.inscripcionesActivas ?? []).map((ins): TemaDetalleInscripcion => ({
+            id: ins.id,
+            nombre: ins.nombre,
+            correo: ins.correo,
+            carrera: ins.carrera,
+            rut: ins.rut,
+            telefono: ins.telefono,
+            reservadoEn: new Date(ins.reservadoEn),
+          })),
+          creadoEn: temaApi.created_at ? new Date(temaApi.created_at) : null,
+        };
+        this.temaDetalleCargando = false;
+      },
+      error: () => {
+        this.temaDetalleError = 'No se pudo cargar el detalle del tema.';
+        this.temaDetalleCargando = false;
+      },
+    });
+  }
+
+  cerrarDetalleTema() {
+    if (this.temaDetalleCargando) {
+      return;
+    }
+    this.showDetalleTema = false;
+    this.temaDetalle = null;
+    this.temaDetalleError = null;
+  }
+
+  togglePropuestasModal(v: boolean) {
+    this.showPropuestasModal = v;
+    if (v) {
+      this.cargarPropuestas();
+    } else {
+      this.propuestaSeleccionada = null;
+      this.comentarioDecision = '';
+      this.decisionEnCurso = false;
+    }
+  }
+
+  seleccionarPropuesta(p: Propuesta) {
+    this.propuestaSeleccionada = p;
+    this.comentarioDecision = p.comentarioDecision ?? '';
+  }
+
+  aceptarPropuesta() {
+    this.resolverPropuesta('aceptada');
+  }
+
+  rechazarPropuesta() {
+    this.resolverPropuesta('rechazada');
+  }
+
+  private cargarTemas() {
+    this.temasCargando = true;
+    this.temasError = null;
+
+    const perfil = this.currentUserService.getProfile();
+    const opciones = perfil?.id != null ? { usuarioId: perfil.id } : undefined;
+
+    this.temaService
+      .getTemas(opciones)
+      .pipe(finalize(() => (this.temasCargando = false)))
+      .subscribe({
+        next: (temasApi: TemaAPI[]) => {
+          this.temas = temasApi.map((t) => ({
+            id: t.id,
+            titulo: t.titulo,
+            objetivo: t.requisitos?.[0] ?? t.descripcion,
+            descripcion: t.descripcion,
+            rama: t.carrera,
+            cupos: t.cupos,
+            cuposDisponibles: t.cuposDisponibles,
+            requisitos: (t.requisitos?.join(', ') ?? ''),
+            fecha: t.created_at ? new Date(t.created_at) : new Date(),
+            creadoPor: t.creadoPor ?? null,
+            inscripcionesActivas: t.inscripcionesActivas ?? [],
+          }));
+        },
+        error: () => {
+          this.temasError = 'No fue posible cargar los temas disponibles.';
+        },
+      });
+  }
+
+  private cargarPropuestas(force = false) {
+    if (this.propuestasCargando || (this.propuestasCargadas && !force)) {
+      return;
+    }
+
+    const docenteId = this.obtenerDocenteIdActual();
+    if (!docenteId) {
+      this.propuestasError = 'No se pudo determinar el docente actual.';
+      this.propuestas = [];
+      this.propuestasCargadas = true;
+      return;
+    }
+
+    this.propuestasCargando = true;
+    this.propuestasError = null;
+
+    this.propuestaService
+      .listarPorDocente(docenteId)
+      .pipe(finalize(() => (this.propuestasCargando = false)))
+      .subscribe({
+        next: (propuestas) => {
+          this.propuestas = propuestas;
+          this.propuestasCargadas = true;
+        },
+        error: () => {
+          this.propuestasError = 'No fue posible cargar las propuestas.';
+        },
+      });
+  }
+
+  private resolverPropuesta(estado: 'aceptada' | 'rechazada') {
+    if (!this.propuestaSeleccionada) {
+      return;
+    }
+
+    const comentario = this.comentarioDecision.trim();
+    if (!comentario) {
+      return;
+    }
+
+    const docenteId = this.obtenerDocenteIdActual();
+    if (!docenteId) {
+      this.propuestasError = 'No se pudo determinar el docente actual.';
+      return;
+    }
+
+    this.decisionEnCurso = true;
+    this.propuestaService
+      .actualizarPropuesta(this.propuestaSeleccionada.id, {
+        estado,
+        comentarioDecision: comentario,
+        docenteId,
+      })
+      .pipe(finalize(() => (this.decisionEnCurso = false)))
+      .subscribe({
+        next: (actualizada) => {
+          this.propuestas = this.propuestas.map((p) => (p.id === actualizada.id ? actualizada : p));
+          this.togglePropuestasModal(false);
+        },
+        error: () => {
+          this.propuestasError = 'No fue posible actualizar la propuesta.';
+        },
+      });
+  }
+
+  private obtenerDocenteIdActual(): number | null {
+    const perfil = this.currentUserService.getProfile();
+    return perfil?.id ?? null;
+  }
+}

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
@@ -3,12 +3,10 @@
 <div class="tabs">
   <button [class.active]="tab === 'titulo1'" (click)="tab = 'titulo1'; volverAListaGrupos()">T. Título I</button>
   <button [class.active]="tab === 'titulo2'" (click)="tab = 'titulo2'; volverAListaGrupos()">T. Título II</button>
-  <button [class.active]="tab === 'temas'"   (click)="tab = 'temas'">Temas</button>
+  <a class="btn link" routerLink="/docente/temas">Gestionar temas</a>
 </div>
 
-<!-- TÍTULO I / II -->
 <div *ngIf="tab === 'titulo1' || tab === 'titulo2'">
-  <!-- Lista de grupos -->
   <ng-container *ngIf="!grupoSeleccionado; else panelEntregas">
     <h3>Grupos asignados</h3>
 
@@ -23,23 +21,21 @@
           <span class="chip-status" [ngClass]="estadoClase(grupo.estado)">
             {{ estadoTexto(grupo.estado) }}
           </span>
-          <button class="btn-ver" (click)="verGrupo(grupo)">Ver</button>
+          <button class="btn-ver" type="button" (click)="verGrupo(grupo)">Ver</button>
         </div>
       </div>
     </div>
   </ng-container>
 
-  <!-- Panel de ENTREGAS DEL GRUPO -->
   <ng-template #panelEntregas>
     <div class="row-head">
       <div style="display:flex; align-items:center; gap:10px;">
-        <button class="btn light" (click)="volverAListaGrupos()">← Volver</button>
+        <button class="btn light" type="button" (click)="volverAListaGrupos()">← Volver</button>
         <h3 style="margin:0">Entregas — {{ grupoSeleccionado?.nombre }}</h3>
       </div>
       <div class="muted">{{ grupoSeleccionado?.integrantes?.join(' / ') }}</div>
     </div>
 
-    <!-- Filtros -->
     <div class="filtros-bar">
       <select [(ngModel)]="filtroTipo">
         <option *ngFor="let t of tiposEntrega" [value]="t">{{ t }}</option>
@@ -48,7 +44,6 @@
     </div>
 
     <div class="entregas-grid">
-      <!-- Pendientes -->
       <div class="col">
         <h4 class="sec">Pendientes</h4>
         <ng-container *ngIf="hasPendientes; else noPend">
@@ -61,7 +56,7 @@
               {{ e.tipo }} • <ng-container *ngIf="e.fechaLimite">Coordinar antes del {{ e.fechaLimite }}</ng-container>
             </div>
             <div class="hit-actions">
-              <button class="btn primary" (click)="revisarEntrega(e)">Revisar</button>
+              <button class="btn primary" type="button" (click)="revisarEntrega(e)">Revisar</button>
             </div>
           </div>
         </ng-container>
@@ -70,7 +65,6 @@
         </ng-template>
       </div>
 
-      <!-- Evaluadas -->
       <div class="col">
         <h4 class="sec">Evaluadas</h4>
         <ng-container *ngIf="hasEvaluadas; else noEval">
@@ -80,10 +74,10 @@
               <span class="chip chip-ok">Evaluada</span>
             </div>
             <div class="hit-meta muted">
-              Entregada {{ e.fechaEntrega }} • Nota: <b>{{ e.nota }}</b>
+              Entregada {{ e.fechaEntrega }} <span *ngIf="e.nota">• Nota: <b>{{ e.nota }}</b></span>
             </div>
             <div class="hit-actions">
-              <button class="btn light" (click)="toggleResumen(e)">
+              <button class="btn light" type="button" (click)="toggleResumen(e)">
                 {{ e.expanded ? 'Ocultar resumen' : 'Ver resumen' }}
               </button>
             </div>
@@ -101,238 +95,6 @@
   </ng-template>
 </div>
 
-<!-- TEMAS -->
-<div *ngIf="tab === 'temas'">
-  <div class="row-head">
-    <h3>Temas disponibles</h3>
-    <div style="display:flex; gap:10px;">
-      <button type="button" class="btn outline" (click)="togglePropuestasModal(true)">📄 Ver propuestas</button>
-      <button type="button" class="btn primary" (click)="abrirModalTema()">+ Agregar tema</button>
-    </div>
-  </div>
-
-  <ng-container *ngIf="temas.length > 0; else sinTemas">
-    <ul class="temas-list">
-      <li *ngFor="let tema of temas" class="temas-item">
-        <div class="temas-item__header">
-          <div>
-            <h4 class="temas-item__title">{{ tema.titulo }}</h4>
-            <p class="temas-item__objetivo">{{ tema.objetivo }}</p>
-            <div class="temas-item__creator" *ngIf="tema.creadoPor as autor">
-              <span class="temas-item__creator-icon" aria-hidden="true">👤</span>
-              <div>
-                <div class="temas-item__creator-label">
-                  {{ autor.rol === 'docente' ? 'Profesor creador' : 'Creado por' }}:
-                  <span class="temas-item__creator-name">{{ autor.nombre }}</span>
-                </div>
-                <div class="temas-item__creator-meta">
-                  {{ autor.rol | titlecase }}
-                  <ng-container *ngIf="autor.carrera"> · {{ autor.carrera }}</ng-container>
-                </div>
-              </div>
-            </div>
-          </div>
-
-        </div>
-
-        <div class="temas-item__meta">
-          <span class="chip ghost">Cupos: {{ tema.cuposDisponibles }} / {{ tema.cupos }}</span>
-          <span class="chip ghost">Fecha de publicación: {{ tema.fecha | date:'shortDate' }}</span>
-          <span class="chip ghost">Reservas confirmadas: {{ tema.inscripcionesActivas.length }}</span>
-          <span class="badge">{{ tema.rama }}</span>
-        </div>
-
-        <div class="temas-item__actions">
-          <button class="btn light" type="button" (click)="verDetalleTema(tema)">Ver detalle</button>
-          <button class="btn danger" (click)="eliminarTema(tema)" >Eliminar</button>
-        </div>
-      </li>
-    </ul>
-  </ng-container>
-  <ng-template #sinTemas><p class="muted">No hay temas disponibles por ahora.</p></ng-template>
-</div>
-
-<!-- MODAL DETALLE TEMA -->
-<div class="backdrop" *ngIf="showDetalleTema" (click)="cerrarDetalleTema()"></div>
-<div class="modal tema-detalle-modal" *ngIf="showDetalleTema" role="dialog" aria-modal="true">
-  <div class="modal-head">
-    <h4 class="ttl" style="margin:0">Detalle del tema</h4>
-    <button type="button" class="icon" (click)="cerrarDetalleTema()">✕</button>
-  </div>
-
-  <div class="tema-detalle__body">
-    <div class="muted" *ngIf="temaDetalleCargando">Cargando información del tema…</div>
-    <div class="err" *ngIf="temaDetalleError">{{ temaDetalleError }}</div>
-
-    <ng-container *ngIf="!temaDetalleCargando && !temaDetalleError && temaDetalle as detalle">
-      <div class="chips meta">
-        <span class="chip ghost">Cupos disponibles: {{ detalle.cuposDisponibles }} / {{ detalle.cupos }}</span>
-        <span class="chip ghost">Carrera: {{ detalle.carrera }}</span>
-        <span class="chip ghost" *ngIf="detalle.creadoEn">Creado: {{ detalle.creadoEn | date:'shortDate' }}</span>
-      </div>
-
-      <div class="tema-detalle__descripcion">
-        <h4>{{ detalle.titulo }}</h4>
-        <p>{{ detalle.descripcion }}</p>
-      </div>
-
-      <div class="tema-detalle__autor" *ngIf="detalle.creadoPor as autor">
-        <span aria-hidden="true">👤</span>
-        <div>
-          <p class="tema-detalle__autor-nombre">{{ autor.nombre }}</p>
-          <p class="muted">
-            {{ autor.rol | titlecase }}
-            <ng-container *ngIf="autor.carrera"> · {{ autor.carrera }}</ng-container>
-          </p>
-        </div>
-      </div>
-
-      <section class="tema-detalle__seccion">
-        <h5>Requisitos del tema</h5>
-        <ng-container *ngIf="detalle.requisitos.length; else sinRequisitosDoc">
-          <ul>
-            <li *ngFor="let requisito of detalle.requisitos">{{ requisito }}</li>
-          </ul>
-        </ng-container>
-        <ng-template #sinRequisitosDoc>
-          <p class="muted">Este tema no especifica requisitos adicionales.</p>
-        </ng-template>
-      </section>
-
-      <section class="tema-detalle__seccion">
-        <h5>Alumnos con reserva confirmada</h5>
-        <ng-container *ngIf="detalle.inscripciones.length; else sinInscritos">
-          <ul class="tema-detalle__inscritos">
-            <li *ngFor="let alumno of detalle.inscripciones">
-              <div class="inscrito-nombre">{{ alumno.nombre }}</div>
-              <div class="inscrito-meta">
-                <span>{{ alumno.carrera || 'Carrera no registrada' }}</span>
-                <span *ngIf="alumno.rut"> · RUT: {{ alumno.rut }}</span>
-              </div>
-              <div class="inscrito-contacto">
-                <span>Correo: {{ alumno.correo }}</span>
-                <span *ngIf="alumno.telefono"> · Teléfono: {{ alumno.telefono }}</span>
-              </div>
-              <div class="inscrito-reserva muted">Reservado el {{ alumno.reservadoEn | date:'short' }}</div>
-            </li>
-          </ul>
-        </ng-container>
-        <ng-template #sinInscritos>
-          <p class="muted">Aún no hay alumnos inscritos en este tema.</p>
-        </ng-template>
-      </section>
-    </ng-container>
-  </div>
-
-  <div class="actions" style="padding:0 24px 12px;">
-    <button type="button" class="btn light" (click)="cerrarDetalleTema()">Cerrar</button>
-  </div>
-</div>
-
-<!-- MODAL PROPUESAS -->
-<div class="backdrop" *ngIf="showPropuestasModal" (click)="togglePropuestasModal(false)"></div>
-<div class="modal" *ngIf="showPropuestasModal" role="dialog" aria-modal="true">
-  <div class="modal-head">
-    <h4 class="ttl" style="margin:0">Propuestas de Trabajo de Título</h4>
-    <button type="button" class="icon" (click)="togglePropuestasModal(false)">✕</button>
-  </div>
-
-  <div class="muted" *ngIf="propuestasCargando">Cargando propuestas...</div>
-  <div class="err" *ngIf="propuestasError">{{ propuestasError }}</div>
-  <p class="muted" *ngIf="!propuestasCargando && !propuestasError && !propuestas.length">No hay propuestas registradas por ahora.</p>
-
-  <div class="tabla" *ngIf="!propuestasCargando && propuestas.length">
-    <div class="head">
-      <span>Alumno</span><span>Tema</span><span>Rama</span><span>Fecha</span><span>Estado</span><span></span>
-    </div>
-    <div *ngFor="let p of propuestas">
-      <div class="fila">
-        <div>{{ p.alumno?.nombre || 'Sin registro' }}</div>
-        <div>{{ p.titulo }}</div>
-        <div>{{ p.rama }}</div>
-        <div>{{ p.createdAt | date:'shortDate' }}</div>
-        <div>
-          <span class="chip"
-            [class.chip-ok]="p.estado==='aceptada'"
-            [class.chip-bad]="p.estado==='rechazada'"
-            [class.chip-warn]="p.estado==='pendiente'">{{ p.estado | titlecase }}</span>
-        </div>
-        <div><button class="btn sm" (click)="seleccionarPropuesta(p)">Revisar</button></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="detalle" *ngIf="propuestaSeleccionada as sel">
-    <h4>{{ sel.titulo }}</h4>
-    <p><b>Alumno:</b> {{ sel.alumno?.nombre || 'Sin registro' }}</p>
-    <p class="muted"><b>Rama:</b> {{ sel.rama }} — <b>Creada:</b> {{ sel.createdAt | date:'short' }}</p>
-    <p><b>Objetivo:</b> {{ sel.objetivo }}</p>
-    <p><b>Descripción:</b> {{ sel.descripcion }}</p>
-    <p *ngIf="sel.comentarioDecision" class="muted">Último comentario registrado: {{ sel.comentarioDecision }}</p>
-
-    <div class="form">
-      <label for="comentario">Comentario</label>
-      <textarea id="comentario" [(ngModel)]="comentarioDecision" placeholder="Fundamente su decisión..."></textarea>
-      <div class="actions">
-        <button class="btn primary" type="button" (click)="aceptarPropuesta()" [disabled]="!comentarioDecision || decisionEnCurso">Aceptar</button>
-        <button class="btn danger"  type="button" (click)="rechazarPropuesta()" [disabled]="!comentarioDecision || decisionEnCurso">Rechazar</button>
-      </div>
-      <p class="muted" *ngIf="decisionEnCurso">Guardando decisión...</p>
-    </div>
-  </div>
-</div>
-
-<!-- MODAL NUEVO TEMA -->
-<div class="backdrop" *ngIf="showModalTema" (click)="cerrarModalTema()"></div>
-<div class="modal narrow" *ngIf="showModalTema" role="dialog" aria-modal="true">
-  <div class="modal-head">
-    <h4 class="ttl" style="margin:0">Nuevo tema</h4>
-    <button type="button" class="icon" (click)="cerrarModalTema()">✕</button>
-  </div>
-
-  <form class="grid" (ngSubmit)="guardarTema()" novalidate>
-    <div class="field">
-      <label>Nombre del tema <span class="req">*</span></label>
-      <input type="text" [(ngModel)]="nuevoTema.titulo" name="titulo" required />
-    </div>
-
-    <div class="field">
-      <label>Objetivo <span class="req">*</span></label>
-      <input type="text" [(ngModel)]="nuevoTema.objetivo" name="objetivo" required />
-    </div>
-
-    <div class="field full">
-      <label>Breve descripción <span class="req">*</span></label>
-      <textarea [(ngModel)]="nuevoTema.descripcion" name="descripcion" required></textarea>
-    </div>
-
-    <div class="field">
-      <label>Rama de la carrera <span class="req">*</span></label>
-      <select [(ngModel)]="nuevoTema.rama" name="rama" required>
-        <option value="">Selecciona una rama</option>
-        <option *ngFor="let r of ramas" [value]="r">{{ r }}</option>
-      </select>
-      <div class="err" *ngIf="!nuevoTema.rama">Obligatorio.</div>
-    </div>
-
-    <div class="field">
-      <label>Cupos</label>
-      <input type="number" [(ngModel)]="nuevoTema.cupos" name="cupos" min="1" />
-    </div>
-
-    <div class="field full">
-      <label>Requisitos (separados por coma)</label>
-      <input type="text" [(ngModel)]="nuevoTema.requisitos" name="requisitos" placeholder="Ej: Linux, Git, Metodologías ágiles"/>
-    </div>
-
-    <div class="actions full">
-      <button type="button" class="btn light" (click)="cerrarModalTema()">Cancelar</button>
-      <button type="submit" class="btn primary">Guardar tema</button>
-    </div>
-  </form>
-</div>
-
-<!-- MODAL EVALUACIÓN -->
 <div class="backdrop" *ngIf="showEvalModal" (click)="cerrarEvalModal()"></div>
 <div class="modal narrow" *ngIf="showEvalModal" role="dialog" aria-modal="true">
   <div class="modal-head">
@@ -349,7 +111,7 @@
 
     <div class="field">
       <label>Nota (1.0 a 7.0) <span class="req">*</span></label>
-      <input type="number" min="1" max="7" step="0.1" [(ngModel)]="notaInput" name="nota" required/>
+      <input type="number" min="1" max="7" step="0.1" [(ngModel)]="notaInput" name="nota" required />
     </div>
 
     <div class="field full">

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
@@ -1,92 +1,41 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { finalize } from 'rxjs';
-import { HttpClientModule } from '@angular/common/http';
-import { TemaService, TemaDisponible as TemaAPI, CrearTemaPayload, TemaInscripcionActiva } from './tema.service';
-import { PropuestaService, Propuesta } from '../../../shared/services/propuesta.service';
-import { CurrentUserService } from '../../../shared/services/current-user.service';
+import { RouterLink } from '@angular/router';
 
-type Tab = 'titulo1' | 'titulo2' | 'temas';
+type Tab = 'titulo1' | 'titulo2';
 type EstadoGrupo = 'pendiente' | 'en_revision' | 'aprobado' | 'finalizado';
 type EstadoEntrega = 'pendiente' | 'evaluado';
 
-/** ====== MODELOS DE LA VISTA (UI) ====== */
-interface Grupo {
+type Grupo = {
   id: string;
   nombre: string;
   integrantes: string[];
   estado: EstadoGrupo;
-}
+};
 
-interface Entrega {
+type Entrega = {
   id: string;
   titulo: string;
-  tipo: string;            // "Plan de trabajo" | "Bitácora" | "Reunión" | "Informe"
-  estado: EstadoEntrega;   // pendiente | evaluado
+  tipo: string;
+  estado: EstadoEntrega;
   fechaLimite?: string;
   fechaEntrega?: string;
   nota?: number;
   comentarios?: string;
   expanded?: boolean;
-}
-
-/** Tema usado en la UI. Incluye id para poder eliminar en backend */
-interface TemaCreator {
-  nombre: string;
-  rol: string;
-  carrera: string | null;
-}
-
-interface TemaDisponible {
-  id?: number;
-  titulo: string;
-  objetivo: string;        // En backend no existe; lo derivamos de requisitos[0] o join
-  descripcion: string;
-  rama: string;            // Mapea a "carrera" del backend
-  cupos: number;
-  cuposDisponibles: number;
-  requisitos: string;
-  fecha: Date;             // Mapea a created_at
-  creadoPor: TemaCreator | null;
-  inscripcionesActivas: TemaInscripcionActiva[];
-}
-
-interface TemaDetalleInscripcion {
-  id: number;
-  nombre: string;
-  correo: string;
-  carrera: string | null;
-  rut: string | null;
-  telefono: string | null;
-  reservadoEn: Date;
-}
-
-interface TemaDetalleDocente {
-  id: number;
-  titulo: string;
-  descripcion: string;
-  carrera: string;
-  cupos: number;
-  cuposDisponibles: number;
-  requisitos: string[];
-  creadoPor: TemaCreator | null;
-  inscripciones: TemaDetalleInscripcion[];
-  creadoEn: Date | null;
-}
+};
 
 @Component({
   selector: 'docente-trabajo-list',
   standalone: true,
-  imports: [CommonModule, FormsModule, HttpClientModule],
+  imports: [CommonModule, FormsModule, RouterLink],
   templateUrl: './docente-trabajo-list.component.html',
   styleUrls: ['./docente-trabajo-list.component.css'],
 })
-export class DocenteTrabajoListComponent implements OnInit {
-  // ===== pestañas
+export class DocenteTrabajoListComponent {
   tab: Tab = 'titulo1';
 
-  // ===== grupos (mock UI)
   gruposTitulo1: Grupo[] = [
     { id: 'g1', nombre: 'Grupo 1', integrantes: ['Peña', 'Muñoz'], estado: 'aprobado' },
     { id: 'g2', nombre: 'Grupo 2', integrantes: ['Jiménez', 'Quezada'], estado: 'en_revision' },
@@ -97,428 +46,152 @@ export class DocenteTrabajoListComponent implements OnInit {
     { id: 'g4', nombre: 'Grupo 4', integrantes: ['Morales', 'Rojas'], estado: 'finalizado' },
   ];
 
-  estadoTexto(e: EstadoGrupo): string {
-    switch (e) {
-      case 'pendiente': return 'Pendiente';
-      case 'en_revision': return 'En revisión';
-      case 'aprobado': return 'Aprobado';
-      case 'finalizado': return 'Finalizado';
-      default: return e;
-    }
-  }
-  estadoClase(e: EstadoGrupo): string {
-    switch (e) {
-      case 'pendiente': return 'chip-pend';
-      case 'en_revision': return 'chip-rev';
-      case 'aprobado': return 'chip-ok';
-      case 'finalizado': return 'chip-done';
-      default: return '';
-    }
-  }
-
-  // ===== panel de entregas (mock UI)
   grupoSeleccionado: Grupo | null = null;
   entregas: Entrega[] = [];
 
-  // filtros
   tiposEntrega = ['Todos', 'Plan de trabajo', 'Bitácora', 'Reunión', 'Informe'];
-  filtroTipo: string = 'Todos';
-  filtroBusqueda: string = '';
+  filtroTipo = 'Todos';
+  filtroBusqueda = '';
+
+  showEvalModal = false;
+  entregaEnRevision: Entrega | null = null;
+  notaInput: number | null = null;
+  comentariosInput = '';
+
+  estadoTexto(estado: EstadoGrupo): string {
+    switch (estado) {
+      case 'pendiente':
+        return 'Pendiente';
+      case 'en_revision':
+        return 'En revisión';
+      case 'aprobado':
+        return 'Aprobado';
+      case 'finalizado':
+        return 'Finalizado';
+      default:
+        return estado;
+    }
+  }
+
+  estadoClase(estado: EstadoGrupo): string {
+    switch (estado) {
+      case 'pendiente':
+        return 'chip-pend';
+      case 'en_revision':
+        return 'chip-rev';
+      case 'aprobado':
+        return 'chip-ok';
+      case 'finalizado':
+        return 'chip-done';
+      default:
+        return '';
+    }
+  }
 
   verGrupo(grupo: Grupo) {
     this.grupoSeleccionado = grupo;
     this.filtroTipo = 'Todos';
     this.filtroBusqueda = '';
 
-    // Mock: reemplazar por servicio real si más adelante conectas entregas
     this.entregas = [
-      { id: 'e1', titulo: 'Hito 1 · Plan de trabajo', tipo: 'Plan de trabajo', estado: 'evaluado', fechaEntrega: '08 abr 2024', nota: 6.5, comentarios: 'Buen alcance y cronograma claro. Ajustar sección de riesgos.' },
-      { id: 'e2', titulo: 'Bitácora Semanal #5',      tipo: 'Bitácora',      estado: 'pendiente', fechaLimite: '02 may 2024' },
-      { id: 'e3', titulo: 'Reunión de seguimiento',   tipo: 'Reunión',       estado: 'pendiente', fechaLimite: '25 abr 2024' },
-      { id: 'e4', titulo: 'Informe intermedio',       tipo: 'Informe',       estado: 'evaluado',  fechaEntrega: '10 may 2024', nota: 6.0, comentarios: 'Buen análisis, profundizar en el marco comparativo.' },
+      {
+        id: 'e1',
+        titulo: 'Hito 1 · Plan de trabajo',
+        tipo: 'Plan de trabajo',
+        estado: 'evaluado',
+        fechaEntrega: '08 abr 2024',
+        nota: 6.5,
+        comentarios: 'Buen alcance y cronograma claro. Ajustar sección de riesgos.',
+      },
+      {
+        id: 'e2',
+        titulo: 'Bitácora Semanal #5',
+        tipo: 'Bitácora',
+        estado: 'pendiente',
+        fechaLimite: '02 may 2024',
+      },
+      {
+        id: 'e3',
+        titulo: 'Reunión de seguimiento',
+        tipo: 'Reunión',
+        estado: 'pendiente',
+        fechaLimite: '25 abr 2024',
+      },
+      {
+        id: 'e4',
+        titulo: 'Informe intermedio',
+        tipo: 'Informe',
+        estado: 'evaluado',
+        fechaEntrega: '10 may 2024',
+        nota: 6.0,
+        comentarios: 'Buen análisis, profundizar en el marco comparativo.',
+      },
     ];
   }
+
   volverAListaGrupos() {
     this.grupoSeleccionado = null;
     this.entregas = [];
   }
 
   get entregasFiltradas(): Entrega[] {
-    const q = this.filtroBusqueda.trim().toLowerCase();
-    return this.entregas.filter(e => {
-      const matchTipo = this.filtroTipo === 'Todos' || e.tipo === this.filtroTipo;
-      const matchTexto = !q || e.titulo.toLowerCase().includes(q) || e.tipo.toLowerCase().includes(q);
-      return matchTipo && matchTexto;
+    const texto = this.filtroBusqueda.trim().toLowerCase();
+    return this.entregas.filter((entrega) => {
+      const coincideTipo = this.filtroTipo === 'Todos' || entrega.tipo === this.filtroTipo;
+      const coincideBusqueda =
+        !texto ||
+        entrega.titulo.toLowerCase().includes(texto) ||
+        entrega.tipo.toLowerCase().includes(texto);
+      return coincideTipo && coincideBusqueda;
     });
   }
 
-  // helpers para el template (evitar funciones flecha en HTML)
   get hasPendientes(): boolean {
-    return this.entregasFiltradas.some(e => e.estado === 'pendiente');
+    return this.entregasFiltradas.some((entrega) => entrega.estado === 'pendiente');
   }
+
   get hasEvaluadas(): boolean {
-    return this.entregasFiltradas.some(e => e.estado === 'evaluado');
+    return this.entregasFiltradas.some((entrega) => entrega.estado === 'evaluado');
   }
 
-  // ===== evaluación (modal)
-  showEvalModal = false;
-  entregaEnRevision: Entrega | null = null;
-  notaInput: number | null = null;
-  comentariosInput = '';
-
-  revisarEntrega(e: Entrega) {
-    this.entregaEnRevision = e;
+  revisarEntrega(entrega: Entrega) {
+    this.entregaEnRevision = entrega;
     this.notaInput = null;
     this.comentariosInput = '';
     this.showEvalModal = true;
   }
+
   cerrarEvalModal() {
     this.showEvalModal = false;
     this.entregaEnRevision = null;
     this.notaInput = null;
     this.comentariosInput = '';
   }
+
   guardarEvaluacion() {
-    if (!this.entregaEnRevision || this.notaInput == null) return;
-    const idx = this.entregas.findIndex(x => x.id === this.entregaEnRevision!.id);
-    if (idx >= 0) {
-      this.entregas[idx] = {
+    if (!this.entregaEnRevision || this.notaInput == null) {
+      return;
+    }
+
+    const indice = this.entregas.findIndex((entrega) => entrega.id === this.entregaEnRevision!.id);
+    if (indice >= 0) {
+      this.entregas[indice] = {
         ...this.entregaEnRevision,
         estado: 'evaluado',
-        fechaEntrega: new Date().toLocaleDateString('es-CL', { day: '2-digit', month: 'short', year: 'numeric' }),
+        fechaEntrega: new Date().toLocaleDateString('es-CL', {
+          day: '2-digit',
+          month: 'short',
+          year: 'numeric',
+        }),
         nota: this.notaInput,
         comentarios: this.comentariosInput || 'Sin comentarios adicionales.',
       };
     }
+
     this.cerrarEvalModal();
   }
-  toggleResumen(e: Entrega) { e.expanded = !e.expanded; }
 
-  // ===== Temas (conectado a backend)
-  ramas = ['Empresa', 'Desarrollo de software', 'Investigación', 'Artículo', 'I+D', 'Otro'];
-
-  temas: TemaDisponible[] = [];
-  temasCargando = false;
-  temasError: string | null = null;
-
-  showModalTema = false;
-  enviarTema = false;
-  enviarTemaError: string | null = null;
-
-  nuevoTema: Partial<TemaDisponible> = {
-    titulo: '', objetivo: '', descripcion: '', rama: '', cupos: 1, requisitos: '', inscripcionesActivas: []
-  };
-
-  showDetalleTema = false;
-  temaDetalle: TemaDetalleDocente | null = null;
-  temaDetalleCargando = false;
-  temaDetalleError: string | null = null;
-
-   constructor(
-    private temaService: TemaService,
-    private propuestaService: PropuestaService,
-    private currentUserService: CurrentUserService,
-  ) {}
-
-  ngOnInit(): void {
-    // Carga inicial de temas desde el backend
-    this.cargarTemas();
-  }
-
-  private cargarTemas(): void {
-    this.temasCargando = true;
-    this.temasError = null;
-
-    const perfil = this.currentUserService.getProfile();
-    const opciones = perfil?.id != null ? { usuarioId: perfil.id } : undefined;
-
-    this.temaService.getTemas(opciones)
-      .pipe(finalize(() => (this.temasCargando = false)))
-      .subscribe({
-        next: (temasApi: TemaAPI[]) => {
-          // Mapeo de API -> UI
-          this.temas = temasApi.map(t => ({
-            id: t.id,
-            titulo: t.titulo,
-            objetivo: (t.requisitos?.[0] ?? (t.requisitos?.join(', ') ?? '')),
-            descripcion: t.descripcion,
-            rama: t.carrera,
-            cupos: t.cupos,
-            cuposDisponibles: t.cuposDisponibles,
-            requisitos: (t.requisitos?.join(', ') ?? ''),
-            fecha: t.created_at ? new Date(t.created_at) : new Date(),
-            creadoPor: t.creadoPor ?? null,
-            inscripcionesActivas: t.inscripcionesActivas ?? [],
-          }));
-        },
-        error: () => {
-          this.temasError = 'No fue posible cargar los temas disponibles.';
-        }
-      });
-  }
-
-  abrirModalTema() {
-    this.showModalTema = true;
-    this.enviarTemaError = null;
-  }
-  cerrarModalTema() {
-    this.showModalTema = false;
-    this.nuevoTema = { titulo: '', objetivo: '', descripcion: '', rama: '', cupos: 1, requisitos: '', inscripcionesActivas: [] };
-    this.enviarTema = false;
-    this.enviarTemaError = null;
-  }
-
-  guardarTema() {
-    // Validaciones mínimas (UI actual usa ngModel)
-    if (!this.nuevoTema.titulo || !this.nuevoTema.descripcion || !this.nuevoTema.rama) return;
-
-    const requisitosArray =
-      (this.nuevoTema.requisitos ?? '')
-        .toString()
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean);
-
-    const payload: CrearTemaPayload = {
-      titulo: (this.nuevoTema.titulo ?? '').trim(),
-      carrera: (this.nuevoTema.rama ?? '').trim(),
-      descripcion: (this.nuevoTema.descripcion ?? '').trim(),
-      requisitos: requisitosArray,
-      cupos: Number(this.nuevoTema.cupos ?? 1),
-      inscripcionesActivas: [],
-      // created_by: (opcional) si tu backend lo necesita
-    };
-
-    const perfil = this.currentUserService.getProfile();
-    if (perfil?.id) {
-      payload.created_by = perfil.id;
-    }
-
-    const autorActual = perfil
-      ? {
-          nombre: perfil.nombre,
-          rol: perfil.rol,
-          carrera: perfil.carrera ?? null,
-        }
-      : null;
-
-
-    this.enviarTema = true;
-    this.enviarTemaError = null;
-
-    this.temaService.crearTema(payload)
-      .pipe(finalize(() => (this.enviarTema = false)))
-      .subscribe({
-        next: (temaCreado: TemaAPI) => {
-          // Mapeo API -> UI para insertar al inicio manteniendo tu tabla actual
-          const autorRespuesta = temaCreado.creadoPor ?? null;
-          const temaUI: TemaDisponible = {
-            id: temaCreado.id,
-            titulo: temaCreado.titulo,
-            objetivo: (temaCreado.requisitos?.[0] ?? (temaCreado.requisitos?.join(', ') ?? '')),
-            descripcion: temaCreado.descripcion,
-            rama: temaCreado.carrera,
-            cupos: temaCreado.cupos,
-            cuposDisponibles: temaCreado.cuposDisponibles,
-            requisitos: (temaCreado.requisitos?.join(', ') ?? ''),
-            fecha: temaCreado.created_at ? new Date(temaCreado.created_at) : new Date(),
-            creadoPor: autorRespuesta ?? autorActual ?? null,
-            inscripcionesActivas: temaCreado.inscripcionesActivas ?? [],
-          };
-          this.temas = [temaUI, ...this.temas];
-          this.cerrarModalTema();
-        },
-        error: () => {
-          this.enviarTemaError = 'No se pudo guardar el tema. Inténtalo nuevamente.';
-        }
-      });
-  }
-
-  eliminarTema(tema: TemaDisponible) {
-    if (!tema.id) {
-      // Si por alguna razón vino sin id, lo quitamos localmente
-      this.temas = this.temas.filter(t => t !== tema);
-      return;
-    }
-
-    const confirmado = confirm(`¿Está seguro de eliminar el tema "${tema.titulo}"? Esta acción no se puede deshacer.`);
-    if (!confirmado) return;
-
-    this.temaService.eliminarTema(tema.id).subscribe({
-      next: () => {
-        this.temas = this.temas.filter(t => t.id !== tema.id);
-      },
-      error: () => {
-        alert('No se pudo eliminar el tema. Inténtalo nuevamente.');
-      }
-    });
-  }
-
-  verDetalleTema(tema: TemaDisponible) {
-    if (!tema.id) {
-      return;
-    }
-
-    this.showDetalleTema = true;
-    this.temaDetalleError = null;
-    this.temaDetalleCargando = true;
-    this.temaDetalle = {
-      id: tema.id,
-      titulo: tema.titulo,
-      descripcion: tema.descripcion,
-      carrera: tema.rama,
-      cupos: tema.cupos,
-      cuposDisponibles: tema.cuposDisponibles,
-      requisitos: [],
-      creadoPor: tema.creadoPor,
-      inscripciones: [],
-      creadoEn: tema.fecha ?? null,
-    };
-
-    const perfil = this.currentUserService.getProfile();
-    const opciones = perfil?.id != null ? { usuarioId: perfil.id } : undefined;
-
-    this.temaService.obtenerTema(tema.id, opciones).subscribe({
-      next: temaApi => {
-        this.temaDetalle = {
-          id: temaApi.id,
-          titulo: temaApi.titulo,
-          descripcion: temaApi.descripcion,
-          carrera: temaApi.carrera,
-          cupos: temaApi.cupos,
-          cuposDisponibles: temaApi.cuposDisponibles,
-          requisitos: temaApi.requisitos ?? [],
-          creadoPor: temaApi.creadoPor ?? null,
-          inscripciones: (temaApi.inscripcionesActivas ?? []).map((ins): TemaDetalleInscripcion => ({
-            id: ins.id,
-            nombre: ins.nombre,
-            correo: ins.correo,
-            carrera: ins.carrera,
-            rut: ins.rut,
-            telefono: ins.telefono,
-            reservadoEn: new Date(ins.reservadoEn),
-          })),
-          creadoEn: temaApi.created_at ? new Date(temaApi.created_at) : null,
-        };
-        this.temaDetalleCargando = false;
-      },
-      error: () => {
-        this.temaDetalleError = 'No se pudo cargar el detalle del tema.';
-        this.temaDetalleCargando = false;
-      }
-    });
-  }
-
-  cerrarDetalleTema() {
-    if (this.temaDetalleCargando) {
-      return;
-    }
-    this.showDetalleTema = false;
-    this.temaDetalle = null;
-    this.temaDetalleError = null;
-  }
-
-  // ===== Propuestas (conectado a backend)
-  showPropuestasModal = false;
-  propuestaSeleccionada: Propuesta | null = null;
-  comentarioDecision = '';
-  propuestas: Propuesta[] = [];
-  propuestasCargando = false;
-  propuestasError: string | null = null;
-  propuestasCargadas = false;
-  decisionEnCurso = false;
-
-  togglePropuestasModal(v: boolean) {
-    this.showPropuestasModal = v;
-     if (v) {
-      this.cargarPropuestas();
-    } else {
-      this.propuestaSeleccionada = null;
-      this.comentarioDecision = '';
-      this.decisionEnCurso = false;
-    }
-  }
-
-  seleccionarPropuesta(p: Propuesta) {
-    this.propuestaSeleccionada = p;
-     this.comentarioDecision = p.comentarioDecision ?? '';
-  }
-  aceptarPropuesta() {
-    this.resolverPropuesta('aceptada');
-  }
-
-  rechazarPropuesta() {
-   this.resolverPropuesta('rechazada');
-  }
-
-  private cargarPropuestas(force = false) {
-    if (this.propuestasCargando || (this.propuestasCargadas && !force)) {
-      return;
-    }
-
-    const docenteId = this.obtenerDocenteIdActual();
-    if (!docenteId) {
-      this.propuestasError = 'No se pudo determinar el docente actual.';
-      this.propuestas = [];
-      this.propuestasCargadas = true;
-      return;
-    }
-
-    this.propuestasCargando = true;
-    this.propuestasError = null;
-
-    this.propuestaService
-      .listarPorDocente(docenteId)
-      .pipe(finalize(() => (this.propuestasCargando = false)))
-      .subscribe({
-        next: (propuestas) => {
-          this.propuestas = propuestas;
-          this.propuestasCargadas = true;
-        },
-        error: () => {
-          this.propuestasError = 'No fue posible cargar las propuestas.';
-        },
-      });
-  }
-
-  private resolverPropuesta(estado: 'aceptada' | 'rechazada') {
-    if (!this.propuestaSeleccionada) {
-      return;
-    }
-
-    const comentario = this.comentarioDecision.trim();
-    if (!comentario) {
-      return;
-    }
-    const docenteId = this.obtenerDocenteIdActual();
-    if (!docenteId) {
-      this.propuestasError = 'No se pudo determinar el docente actual.';
-      return;
-    }
-
-    this.decisionEnCurso = true;
-    this.propuestaService
-      .actualizarPropuesta(this.propuestaSeleccionada.id, {
-        estado,
-        comentarioDecision: comentario,
-        docenteId,
-      })
-      .pipe(finalize(() => (this.decisionEnCurso = false)))
-      .subscribe({
-        next: (actualizada) => {
-          this.propuestas = this.propuestas.map((p) =>
-            p.id === actualizada.id ? actualizada : p
-          );
-          this.togglePropuestasModal(false);
-        },
-        error: () => {
-          this.propuestasError = 'No fue posible actualizar la propuesta.';
-        },
-      });
-  }
-
-  private obtenerDocenteIdActual(): number | null {
-    const perfil = this.currentUserService.getProfile();
-    return perfil?.id ?? null;
+  toggleResumen(entrega: Entrega) {
+    entrega.expanded = !entrega.expanded;
   }
 }


### PR DESCRIPTION
## Summary
- add a standalone Temas experience for alumnos with topic reservation and proposal workflows, simplifying the existing Trabajo panel to focus on progreso
- add a standalone Temas management screen for docentes, moving topic CRUD and proposal review out of the Trabajo list
- surface the new Temas routes in alumno/docente navigation and application routing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907bae8b2b48324a94a242c18690d2c