### PR TITLE
Add migration ensuring PropuestaTema columns exist

### DIFF
--- a/backend/api/migrations/0019_propuestatema_ensure_columns.py
+++ b/backend/api/migrations/0019_propuestatema_ensure_columns.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+SQL_COMMANDS = [
+    """
+    ALTER TABLE propuestas_tema
+    ADD COLUMN IF NOT EXISTS cupos_requeridos integer NOT NULL DEFAULT 1
+    """,
+    """
+    ALTER TABLE propuestas_tema
+    ADD COLUMN IF NOT EXISTS correos_companeros jsonb NOT NULL DEFAULT '[]'::jsonb
+    """,
+    """
+    ALTER TABLE propuestas_tema
+    ADD COLUMN IF NOT EXISTS cupos_maximo_autorizado integer
+    """,
+]
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0018_propuestatema_cupos_maximo_autorizado_and_more"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(sql, reverse_sql=migrations.RunSQL.noop)
+                for sql in SQL_COMMANDS
+            ],
+            state_operations=[],
+        )
+    ]


### PR DESCRIPTION
## Summary
- add a defensive migration that creates the PropuestaTema cupos fields if they are missing

## Testing
- not run (database not available in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_690c212ac1c08324a1fa576e616d2d18