### PR TITLE
Adjust proposal highlight styling for pending states

### DIFF
--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.css
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.css
@@ -76,6 +76,16 @@
   background: #174bb8;
 }
 
+.btn.danger {
+  background: #dc2626;
+  border-color: #dc2626;
+  color: #fff;
+}
+
+.btn.danger:hover {
+  background: #b91c1c;
+}
+
 .btn[disabled] {
   background: #9ca3af;
   color: #f9fafb;
@@ -383,6 +393,12 @@
   flex-direction: column;
   gap: 8px;
   align-items: flex-start;
+}
+
+.acciones-botones {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .acciones-propuesta .btn {

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.css
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.css
@@ -253,6 +253,12 @@
   color: #b45309;
 }
 
+.chip.warn {
+  background: #fef3c7;
+  border-color: #facc15;
+  color: #92400e;
+}
+
 .alert {
   margin-top: 12px;
   padding: 10px 14px;
@@ -285,11 +291,59 @@
 }
 
 .propuesta-highlight {
-  border: 1px solid #bbf7d0;
-  background: linear-gradient(135deg, rgba(209, 250, 229, 0.9), #ecfeff);
+  --highlight-border: #bbf7d0;
+  --highlight-background: linear-gradient(135deg, rgba(209, 250, 229, 0.9), #ecfeff);
+  --highlight-shadow: rgba(16, 185, 129, 0.18);
+  --highlight-title: #065f46;
+  --highlight-muted: rgba(6, 95, 70, 0.85);
+  --highlight-comment: #0f172a;
+  --highlight-comment-strong: #1a3e6a;
+
+  border: 1px solid var(--highlight-border);
+  background: var(--highlight-background);
   border-radius: 14px;
   padding: 20px;
-  box-shadow: 0 10px 25px rgba(16, 185, 129, 0.18);
+  box-shadow: 0 10px 25px var(--highlight-shadow);
+}
+
+.propuesta-highlight.success {
+  --highlight-border: #bbf7d0;
+  --highlight-background: linear-gradient(135deg, rgba(209, 250, 229, 0.9), #ecfeff);
+  --highlight-shadow: rgba(16, 185, 129, 0.18);
+  --highlight-title: #065f46;
+  --highlight-muted: rgba(6, 95, 70, 0.85);
+  --highlight-comment: #0f172a;
+  --highlight-comment-strong: #1a3e6a;
+}
+
+.propuesta-highlight.pending {
+  --highlight-border: #fb923c;
+  --highlight-background: linear-gradient(135deg, rgba(254, 215, 170, 0.9), #fff7ed);
+  --highlight-shadow: rgba(251, 146, 60, 0.18);
+  --highlight-title: #9a3412;
+  --highlight-muted: rgba(180, 83, 9, 0.85);
+  --highlight-comment: #7c2d12;
+  --highlight-comment-strong: #9a3412;
+}
+
+.propuesta-highlight.warn {
+  --highlight-border: #facc15;
+  --highlight-background: linear-gradient(135deg, rgba(254, 240, 138, 0.9), #fef9c3);
+  --highlight-shadow: rgba(250, 204, 21, 0.2);
+  --highlight-title: #854d0e;
+  --highlight-muted: rgba(133, 77, 14, 0.85);
+  --highlight-comment: #713f12;
+  --highlight-comment-strong: #9a3412;
+}
+
+.propuesta-highlight.error {
+  --highlight-border: #fca5a5;
+  --highlight-background: linear-gradient(135deg, rgba(254, 202, 202, 0.9), #fef2f2);
+  --highlight-shadow: rgba(248, 113, 113, 0.18);
+  --highlight-title: #b91c1c;
+  --highlight-muted: rgba(185, 28, 28, 0.85);
+  --highlight-comment: #7f1d1d;
+  --highlight-comment-strong: #991b1b;
 }
 
 .propuesta-highlight .highlight-head {
@@ -302,25 +356,25 @@
 
 .propuesta-highlight h4 {
   margin: 12px 0 6px;
-  color: #065f46;
+  color: var(--highlight-title);
   font-size: 18px;
   font-weight: 600;
 }
 
 .propuesta-highlight .muted {
-  color: #065f46;
+  color: var(--highlight-muted);
   opacity: 0.85;
 }
 
 .propuesta-highlight .comentario {
   margin-top: 12px;
   font-size: 13px;
-  color: #0f172a;
+  color: var(--highlight-comment);
 }
 
 .propuesta-highlight .comentario span {
   font-weight: 600;
-  color: #1a3e6a;
+  color: var(--highlight-comment-strong);
 }
 
 .acciones-propuesta {

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.html
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.html
@@ -104,6 +104,8 @@
         <div class="err" *ngIf="!propuestasCargando() && propuestasError()">{{ propuestasError() }}</div>
 
         <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
+          <div class="alert error" *ngIf="cancelarPropuestaError()">{{ cancelarPropuestaError() }}</div>
+
           <ng-container *ngIf="propuestaDestacada() as propuestaPrincipal">
             <div
               class="propuesta-highlight"
@@ -134,6 +136,14 @@
                 <button class="btn primary" type="button" (click)="abrirAjustePropuesta(propuestaPrincipal)">
                   Ajustar cupos
                 </button>
+                <button
+                  class="btn danger"
+                  type="button"
+                  (click)="cancelarPropuesta(propuestaPrincipal)"
+                  [disabled]="cancelandoPropuestaId() === propuestaPrincipal.id"
+                >
+                  {{ cancelandoPropuestaId() === propuestaPrincipal.id ? 'Cancelando…' : 'Cancelar propuesta' }}
+                </button>
               </div>
             </div>
           </ng-container>
@@ -156,16 +166,26 @@
                   <div class="chips">
                     <span class="chip ghost">Actualizada {{ propuesta.updatedAt | date:'dd MMM yyyy' }}</span>
                     <span class="chip ghost" *ngIf="propuesta.docente">Docente: {{ propuesta.docente.nombre }}</span>
-                  </div>
-                  <div class="acciones-propuesta" *ngIf="puedeAjustarPropuesta(propuesta)">
+                </div>
+                <div class="acciones-propuesta" *ngIf="puedeAjustarPropuesta(propuesta)">
+                  <div class="acciones-botones">
                     <button class="btn primary sm" type="button" (click)="abrirAjustePropuesta(propuesta)">
                       Ajustar cupos
                     </button>
-                    <span class="muted small">Máximo {{ propuesta.cuposMaximoAutorizado }} integrantes.</span>
+                    <button
+                      class="btn danger sm"
+                      type="button"
+                      (click)="cancelarPropuesta(propuesta)"
+                      [disabled]="cancelandoPropuestaId() === propuesta.id"
+                    >
+                      {{ cancelandoPropuestaId() === propuesta.id ? 'Cancelando…' : 'Cancelar propuesta' }}
+                    </button>
                   </div>
+                  <span class="muted small">Máximo {{ propuesta.cuposMaximoAutorizado }} integrantes.</span>
                 </div>
-              </li>
-            </ul>
+              </div>
+            </li>
+          </ul>
           </div>
 
           <ng-template #sinPropuestas>

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.html
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.html
@@ -105,7 +105,10 @@
 
         <ng-container *ngIf="!propuestasCargando() && !propuestasError()">
           <ng-container *ngIf="propuestaDestacada() as propuestaPrincipal">
-            <div class="propuesta-highlight">
+            <div
+              class="propuesta-highlight"
+              [ngClass]="clasePropuestaDestacadaEstado(propuestaPrincipal.estado)"
+            >
               <div class="highlight-head">
                 <span class="chip" [ngClass]="chipClasePropuesta(propuestaPrincipal.estado)">
                   {{ etiquetaPropuestaDestacada(propuestaPrincipal) }}

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
@@ -195,7 +195,7 @@ export class AlumnoTemasComponent {
       return 'pending';
     }
     if (estado === 'pendiente_ajuste') {
-      return 'warn';
+      return 'pending';
     }
     return 'ghost';
   }
@@ -234,7 +234,7 @@ export class AlumnoTemasComponent {
       return 'pending';
     }
     if (estado === 'pendiente_ajuste') {
-      return 'warn';
+      return 'pending';
     }
     if (estado === 'rechazada') {
       return 'error';

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
@@ -226,6 +226,22 @@ export class AlumnoTemasComponent {
     return 'Propuesta';
   }
 
+  clasePropuestaDestacadaEstado(estado: Propuesta['estado']): string {
+    if (estado === 'aceptada') {
+      return 'success';
+    }
+    if (estado === 'pendiente' || estado === 'pendiente_aprobacion') {
+      return 'pending';
+    }
+    if (estado === 'pendiente_ajuste') {
+      return 'warn';
+    }
+    if (estado === 'rechazada') {
+      return 'error';
+    }
+    return '';
+  }
+
   togglePostulacion(open: boolean) {
     this.showPostulacion.set(open);
     if (open) {

--- a/frontend/src/app/shared/services/propuesta.service.ts
+++ b/frontend/src/app/shared/services/propuesta.service.ts
@@ -161,6 +161,10 @@ export class PropuestaService {
     );
   }
 
+  eliminarPropuesta(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}${id}/`);
+  }
+
   private mapPropuesta(api: PropuestaApi): Propuesta {
     return {
       id: api.id,


### PR DESCRIPTION
## Summary
- add a helper to expose the highlighted proposal state in the alumno temas view
- apply state-based classes in the template so pending proposals no longer appear as accepted
- extend the highlight and chip styles to render pending and warning states with orange/yellow accents

## Testing
- npm run build *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_690cf6eb20608324be8d5cb55af95ade