### PR TITLE
feat: sync reserved thesis theme between pages

### DIFF
--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -20,6 +20,14 @@ class CarrerasCoincidenTests(SimpleTestCase):
     def test_carreras_distintas_no_coinciden(self):
         self.assertFalse(_carreras_coinciden("Química Industrial", "Informática"))
 
+    def test_carrera_con_tokens_adicionales_coincide(self):
+        self.assertTrue(
+            _carreras_coinciden(
+                "Trabajo de Título Informática",
+                "Ingeniería Civil Informática",
+            )
+        )
+
 
 class TemaDisponibleAPITestCase(APITestCase):
     def setUp(self):

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,10 +1,24 @@
 import json
 
+from django.test import SimpleTestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
 
 from .models import PropuestaTema, TemaDisponible, Usuario, Notificacion, InscripcionTema
+from .views import _carreras_coinciden
+
+
+class CarrerasCoincidenTests(SimpleTestCase):
+    def test_computacion_e_informatica_son_equivalentes(self):
+        self.assertTrue(_carreras_coinciden("Computación", "Informática"))
+
+    def test_mencion_informatica_equivale_a_computacion(self):
+        carrera_alumno = "Ingeniería Civil en Computación mención Informática"
+        self.assertTrue(_carreras_coinciden(carrera_alumno, "Computación"))
+
+    def test_carreras_distintas_no_coinciden(self):
+        self.assertFalse(_carreras_coinciden("Química Industrial", "Informática"))
 
 
 class TemaDisponibleAPITestCase(APITestCase):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -247,10 +247,53 @@ def _normalizar_texto(valor: str | None) -> str:
     return texto.casefold().strip()
 
 
+_CARRERA_TOKENS_STOPWORDS = {
+    "en",
+    "de",
+    "del",
+    "la",
+    "el",
+    "y",
+    "ing",
+    "ingenieria",
+    "civil",
+    "mencion",
+    "plan",
+    "comun",
+}
+
+
+_CARRERA_TOKEN_EQUIVALENCIAS = {
+    "informatica": "computacion",
+    "computacion": "computacion",
+    "industria": "industrial",
+}
+
+
+def _normalizar_carrera(valor: str | None) -> str:
+    if not valor:
+        return ""
+
+    texto = _normalizar_texto(valor)
+    tokens = [token for token in re.split(r"[^a-z0-9]+", texto) if token]
+
+    relevantes = [token for token in tokens if token not in _CARRERA_TOKENS_STOPWORDS]
+    candidatos = relevantes or tokens
+    if not candidatos:
+        return ""
+
+    principal = candidatos[0]
+    return _CARRERA_TOKEN_EQUIVALENCIAS.get(principal, principal)
+
+
 def _carreras_coinciden(a: str | None, b: str | None) -> bool:
-    if not a or not b:
+    carrera_a = _normalizar_carrera(a)
+    carrera_b = _normalizar_carrera(b)
+
+    if not carrera_a or not carrera_b:
         return False
-    return _normalizar_texto(a) == _normalizar_texto(b)
+
+    return carrera_a == carrera_b
 
 
 def _filtrar_queryset_por_carrera(queryset, carrera: str | None):

--- a/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
+++ b/frontend/src/app/features/alumno/temas/alumno-temas.component.ts
@@ -683,6 +683,7 @@ export class AlumnoTemasComponent {
         this.reservaError.set(null);
         this.temaPorConfirmar.set(null);
         this.reservandoTemaId.set(null);
+        this.temaService.notificarTemaAsignado(actualizado);
         if (this.puedeMostrarGestionCupos(actualizado)) {
           this.abrirGestionCupos(actualizado);
         }

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -1,6 +1,7 @@
-import { Component, computed, signal } from '@angular/core';
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { CurrentUserService } from '../../../shared/services/current-user.service';
 import { TemaService, TemaDisponible, TemaInscripcionActiva } from '../../docente/trabajolist/tema.service';
@@ -68,6 +69,8 @@ const CARRERAS_NIVEL_I_Y_II = new Set(
   styleUrls: ['./alumno-trabajo.component.css'],
 })
 export class AlumnoTrabajoComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
   readonly nivelesDisponibles = signal<Nivel[]>(['i', 'ii']);
   readonly nivelSeleccionado = signal<Nivel>('i');
 
@@ -241,6 +244,14 @@ export class AlumnoTrabajoComponent {
   ) {
     this.configurarNivelesDisponibles();
     this.cargarTemaAsignado();
+
+    this.temaService.temaAsignado$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((tema) => {
+        this.temaAsignadoError.set(null);
+        this.temaAsignadoCargando.set(false);
+        this.temaAsignado.set(tema);
+      });
   }
 
   tieneNivel(nivel: Nivel): boolean {
@@ -313,6 +324,7 @@ export class AlumnoTrabajoComponent {
           const reservado = temas.find(tema => tema.tieneCupoPropio) ?? null;
           this.temaAsignado.set(reservado);
           this.temaAsignadoCargando.set(false);
+          this.temaService.notificarTemaAsignado(reservado);
         },
         error: (err) => {
           console.error('No fue posible cargar tu tema asignado', err);

--- a/frontend/src/app/features/docente/trabajolist/tema.service.ts
+++ b/frontend/src/app/features/docente/trabajolist/tema.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, ReplaySubject } from 'rxjs';
 
 export interface TemaInscripcionActiva {
   id: number;
@@ -49,6 +49,9 @@ export type CrearTemaPayload = Omit<
 @Injectable({ providedIn: 'root' })
 export class TemaService {
   private readonly baseUrl = 'http://localhost:8000/api/temas/';
+  private readonly temaAsignadoSubject = new ReplaySubject<TemaDisponible | null>(1);
+
+  readonly temaAsignado$ = this.temaAsignadoSubject.asObservable();
 
   constructor(private http: HttpClient) {}
 
@@ -114,6 +117,10 @@ export class TemaService {
       alumno: alumnoId,
       correos,
     });
+  }
+
+  notificarTemaAsignado(tema: TemaDisponible | null): void {
+    this.temaAsignadoSubject.next(tema);
   }
 
   eliminarTema(id: number): Observable<void> {


### PR DESCRIPTION
## Summary
- add a shared subject in the thesis theme service to publish the reserved topic for the logged student
- notify the shared stream when the student reserves a theme so cupo updates propagate across views
- subscribe to the shared stream in the Trabajo de Título page to display the reserved group immediately

## Testing
- npm run build *(fails because of existing Angular budget limits)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dfa51c4ac83248a2f66093e53bea0)