### PR TITLE
Separate alumno and docente proposal admin views

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -3,7 +3,13 @@
 from django import forms
 from django.contrib import admin
 
-from .models import Usuario, PropuestaTema, Notificacion, PracticaDocumento
+from .models import (
+    Usuario,
+    PropuestaTema,
+    PropuestaTemaDocente,
+    Notificacion,
+    PracticaDocumento,
+)
 
 
 class UsuarioAdminForm(forms.ModelForm):
@@ -40,8 +46,14 @@ class UsuarioAdmin(admin.ModelAdmin):
     list_filter = ("rol", "carrera")
 
 
+class BasePropuestaTemaAdmin(admin.ModelAdmin):
+    list_filter = ("estado", "rama")
+    ordering = ("-created_at",)
+    readonly_fields = ("created_at", "updated_at")
+
+
 @admin.register(PropuestaTema)
-class PropuestaTemaAdmin(admin.ModelAdmin):
+class PropuestaTemaAlumnoAdmin(BasePropuestaTemaAdmin):
     list_display = (
         "titulo",
         "alumno",
@@ -49,8 +61,38 @@ class PropuestaTemaAdmin(admin.ModelAdmin):
         "estado",
         "created_at",
     )
-    list_filter = ("estado", "rama")
-    search_fields = ("titulo", "descripcion", "alumno__nombre_completo", "docente__nombre_completo")
+    search_fields = (
+        "titulo",
+        "descripcion",
+        "alumno__nombre_completo",
+        "docente__nombre_completo",
+    )
+    raw_id_fields = ("alumno", "docente")
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.filter(alumno__isnull=False)
+
+
+@admin.register(PropuestaTemaDocente)
+class PropuestaTemaDocenteAdmin(BasePropuestaTemaAdmin):
+    list_display = (
+        "titulo",
+        "docente",
+        "estado",
+        "created_at",
+    )
+    search_fields = (
+        "titulo",
+        "descripcion",
+        "docente__nombre_completo",
+    )
+    exclude = ("alumno",)
+    raw_id_fields = ("docente",)
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.filter(alumno__isnull=True)
 
 
 @admin.register(Notificacion)

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -240,9 +240,20 @@ class PropuestaTema(models.Model):
     class Meta:
         db_table = "propuestas_tema"
         ordering = ["-created_at"]
+        verbose_name = "Propuesta tema alumno"
+        verbose_name_plural = "Propuestas temas alumno"
 
     def __str__(self) -> str:
         return f"{self.titulo} ({self.get_estado_display()})"
+
+
+class PropuestaTemaDocente(PropuestaTema):
+    """Proxy model para separar las propuestas creadas por docentes."""
+
+    class Meta:
+        proxy = True
+        verbose_name = "Propuesta tema docente"
+        verbose_name_plural = "Propuestas tema docente"
 
 
 class Notificacion(models.Model):


### PR DESCRIPTION
## Summary
- rename the existing proposal model so it shows up in the admin as "Propuestas temas alumno"
- add a proxy model for docente proposals and expose it in the admin
- tailor the admin listings and filters for both alumno and docente proposal views

## Testing
- python manage.py test *(fails: default database name is not configured in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1214a8f883249694242b4bf0a0a4)