### PR TITLE
Add student restriction guidelines to thesis workspace

### DIFF
--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
@@ -735,6 +735,50 @@ textarea {
   line-height: 1.4;
 }
 
+.restricciones {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.restricciones-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.restricciones-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.restriccion-icon {
+  font-size: 20px;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.restriccion-texto h4 {
+  margin: 0 0 6px;
+  font-size: 15px;
+  color: #1a3e6a;
+}
+
+.restriccion-texto p {
+  margin: 0;
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 @media (max-width: 860px) {
   .grid {
     grid-template-columns: 1fr;

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -146,4 +146,18 @@
       <a routerLink="/alumno/temas">Temas</a>.
     </p>
   </ng-template>
+
+  <section class="restricciones" aria-labelledby="restricciones-titulo">
+    <h3 id="restricciones-titulo" class="section-title">Restricciones para estudiantes</h3>
+    <p class="muted">Estas políticas definen qué acciones están limitadas dentro del proceso de trabajo de título.</p>
+    <ul class="restricciones-list">
+      <li *ngFor="let item of restricciones()">
+        <span class="restriccion-icon" aria-hidden="true">⚠️</span>
+        <div class="restriccion-texto">
+          <h4>{{ item.titulo }}</h4>
+          <p>{{ item.descripcion }}</p>
+        </div>
+      </li>
+    </ul>
+  </section>
 </div>

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -34,6 +34,11 @@ type EntregaDestacada = EntregaAlumno & {
   encabezado: string;
 };
 
+type Restriccion = {
+  titulo: string;
+  descripcion: string;
+};
+
 const CARRERAS_SIN_TRABAJO_TITULO = new Set(
   [
     'Bachillerato en Ciencias de la Ingeniería',
@@ -162,6 +167,44 @@ export class AlumnoTrabajoComponent {
       profesorGuia: 'Prof. Ana Díaz',
     },
   });
+
+  readonly restricciones = signal<Restriccion[]>([
+    {
+      titulo: 'Un solo tema activo',
+      descripcion:
+        'Solo puedes tener un trabajo de título activo a la vez. Si necesitas cambiar de tema debes gestionar primero la liberación del actual con la coordinación.',
+    },
+    {
+      titulo: 'Entregas solo en etapas habilitadas',
+      descripcion:
+        'Las entregas pueden subirse únicamente cuando la coordinación habilita la etapa correspondiente; fuera de esas ventanas los envíos quedan bloqueados.',
+    },
+    {
+      titulo: 'Sin edición tras confirmar',
+      descripcion:
+        'Una vez que confirmas una entrega el archivo queda bloqueado para resguardar la integridad documental, por lo que no podrás reemplazarlo.',
+    },
+    {
+      titulo: 'Formularios completos',
+      descripcion:
+        'Todos los campos obligatorios deben estar completados para enviar solicitudes o entregas; los formularios incompletos no se pueden enviar.',
+    },
+    {
+      titulo: 'Certificados solo al finalizar etapas',
+      descripcion:
+        'No se habilita la emisión de certificados hasta que finalices todas las etapas del proceso de título según tu malla.',
+    },
+    {
+      titulo: 'Descarga tras validación',
+      descripcion:
+        'La descarga de certificados estará disponible únicamente después de que la coordinación valide el documento; no se generan automáticamente.',
+    },
+    {
+      titulo: 'Documentos internos protegidos',
+      descripcion:
+        'Los documentos de revisión interna de docentes o coordinación, como rúbricas privadas u observaciones, no están visibles para estudiantes.',
+    },
+  ]);
 
   readonly nivelActual = computed<Nivel | null>(() => {
     const seleccionado = this.nivelSeleccionado();

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -170,39 +170,74 @@ export class AlumnoTrabajoComponent {
 
   readonly restricciones = signal<Restriccion[]>([
     {
-      titulo: 'Un solo tema activo',
+      titulo: 'Una postulación activa por alumno',
       descripcion:
-        'Solo puedes tener un trabajo de título activo a la vez. Si necesitas cambiar de tema debes gestionar primero la liberación del actual con la coordinación.',
+        'Si ya tienes una postulación en estado pendiente, en revisión, aceptada o rechazada con observaciones no podrás crear otra hasta que se cierre la actual.',
+    },
+    {
+      titulo: 'Sin edición de postulación tras el envío',
+      descripcion:
+        'Una vez enviada la postulación queda bloqueada. Solo vuelve a estar editable si el docente la marca como “observada”.',
+    },
+    {
+      titulo: 'Contenido filtrado por carrera',
+      descripcion:
+        'Solo verás docentes, propuestas y temáticas asociadas a tu carrera (career_id/codigo_carrera) para asegurar la pertinencia del proceso.',
     },
     {
       titulo: 'Entregas solo en etapas habilitadas',
       descripcion:
-        'Las entregas pueden subirse únicamente cuando la coordinación habilita la etapa correspondiente; fuera de esas ventanas los envíos quedan bloqueados.',
+        'Cada entrega se habilita únicamente si la etapa está activa y dentro de las fechas publicadas por la coordinación.',
     },
     {
-      titulo: 'Sin edición tras confirmar',
+      titulo: 'Entregas bloqueadas tras confirmar',
       descripcion:
-        'Una vez que confirmas una entrega el archivo queda bloqueado para resguardar la integridad documental, por lo que no podrás reemplazarlo.',
+        'Al confirmar una entrega el archivo queda protegido; el botón de edición se oculta para mantener la integridad documental.',
+    },
+    {
+      titulo: 'Evaluaciones docentes cuando están publicadas',
+      descripcion:
+        'Los comentarios y resultados del docente solo se muestran cuando visible == true, tras la publicación de la retroalimentación.',
+    },
+    {
+      titulo: 'Agendamiento condicionado a profesor guía',
+      descripcion:
+        'Solo puedes agendar reuniones si cuentas con profesor guía asignado y el calendario se encuentra publicado (docente_asignado y calendario_publicado).',
+    },
+    {
+      titulo: 'Validación de archivos al subir',
+      descripcion:
+        'El sistema acepta únicamente archivos .pdf, .docx o .zip con un máximo de 25 MB, validado tanto en frontend como en backend.',
     },
     {
       titulo: 'Formularios completos',
       descripcion:
-        'Todos los campos obligatorios deben estar completados para enviar solicitudes o entregas; los formularios incompletos no se pueden enviar.',
+        'Las solicitudes y entregas se pueden enviar únicamente si todos los campos obligatorios están completos; no se permiten formularios incompletos.',
     },
     {
-      titulo: 'Certificados solo al finalizar etapas',
+      titulo: 'Certificados tras finalizar el proceso',
       descripcion:
-        'No se habilita la emisión de certificados hasta que finalices todas las etapas del proceso de título según tu malla.',
+        'El certificado de aprobación se habilita solo si status_proceso == "finalizado" y evaluacion_final == "aprobada".',
     },
     {
-      titulo: 'Descarga tras validación',
+      titulo: 'Descarga de actas validada',
       descripcion:
-        'La descarga de certificados estará disponible únicamente después de que la coordinación valide el documento; no se generan automáticamente.',
+        'Las actas pueden descargarse únicamente cuando cuentan con la firma del docente (acta_firmada) y la validación de la coordinación.',
+    },
+    {
+      titulo: 'Integrantes fijos tras postular',
+      descripcion:
+        'Al enviar la postulación queda bloqueada la edición del grupo de trabajo para mantener consistencia en el registro de integrantes.',
+    },
+    {
+      titulo: 'Acceso restringido a otros grupos',
+      descripcion:
+        'No es posible visualizar documentos o procesos de otros estudiantes; el aislamiento se asegura por grupo_id desde el backend.',
     },
     {
       titulo: 'Documentos internos protegidos',
       descripcion:
-        'Los documentos de revisión interna de docentes o coordinación, como rúbricas privadas u observaciones, no están visibles para estudiantes.',
+        'Las rúbricas internas, observaciones privadas y otros documentos de revisión docente o de coordinación no están disponibles para los estudiantes.',
     },
   ]);
 

--- a/frontend/src/app/features/docente/dashboard/docente-dashboard.component.css
+++ b/frontend/src/app/features/docente/dashboard/docente-dashboard.component.css
@@ -199,6 +199,57 @@ select:focus {
   min-width: 40px;
 }
 
+.restricciones {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.restricciones-intro {
+  margin: 0 0 12px;
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.restricciones-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.restricciones-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.restriccion-icon {
+  font-size: 20px;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.restriccion-texto h4 {
+  margin: 0 0 6px;
+  font-size: 0.95rem;
+  color: #1a3e6a;
+}
+
+.restriccion-texto p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
 .observations-panel {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/features/docente/dashboard/docente-dashboard.component.html
+++ b/frontend/src/app/features/docente/dashboard/docente-dashboard.component.html
@@ -96,3 +96,20 @@
     </div>
   </div>
 </div>
+
+<section class="restricciones" aria-labelledby="restricciones-docente-titulo">
+  <h3 id="restricciones-docente-titulo" class="section-title">Restricciones para docentes</h3>
+  <p class="restricciones-intro">
+    Estas políticas delimitan el acceso y las acciones disponibles dentro del proceso de trabajo de título. Todas se
+    aplican automáticamente según la información registrada en el sistema institucional.
+  </p>
+  <ul class="restricciones-list">
+    <li *ngFor="let item of restricciones()">
+      <span class="restriccion-icon" aria-hidden="true">⚠️</span>
+      <div class="restriccion-texto">
+        <h4>{{ item.titulo }}</h4>
+        <p>{{ item.descripcion }}</p>
+      </div>
+    </li>
+  </ul>
+</section>

--- a/frontend/src/app/features/docente/dashboard/docente-dashboard.component.ts
+++ b/frontend/src/app/features/docente/dashboard/docente-dashboard.component.ts
@@ -1,7 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
+type RestriccionDocente = {
+  titulo: string;
+  descripcion: string;
+};
 
 @Component({
   selector: 'app-dashboard',
@@ -56,4 +60,72 @@ export class DocenteDashboardComponent {
 
   obs: string = '';
   obs2: string = '';
+
+  readonly restricciones = signal<RestriccionDocente[]>([
+    {
+      titulo: 'Visibilidad limitada por carrera',
+      descripcion:
+        'Solo puede revisar postulaciones y entregas de estudiantes asociados a su carrera mediante el filtro career_id/codigo_carrera.',
+    },
+    {
+      titulo: 'Gestión restringida de propuestas',
+      descripcion:
+        'Únicamente visualiza y administra propuestas propias; las creadas por otros docentes permanecen bloqueadas para edición o eliminación.',
+    },
+    {
+      titulo: 'Sin cambios en propuestas con postulaciones activas',
+      descripcion:
+        'Cuando con_postulaciones == true la propuesta queda fija y no puede ser actualizada mientras existan postulantes asociados.',
+    },
+    {
+      titulo: 'Aceptación válida solo para sus propuestas',
+      descripcion:
+        'Puede aceptar estudiantes únicamente si se postularon a sus propuestas; no es posible autoasignarse postulantes externos.',
+    },
+    {
+      titulo: 'Actas tras finalizar rúbricas y retroalimentación',
+      descripcion:
+        'La carga de actas se habilita una vez completada la evaluación por rúbrica y publicada la retroalimentación correspondiente.',
+    },
+    {
+      titulo: 'Agenda activa para recibir solicitudes',
+      descripcion:
+        'Las reuniones se pueden agendar solo si el docente publicó disponibilidad; se requiere calendario_publicado == true.',
+    },
+    {
+      titulo: 'Acceso a entregas exclusivamente de estudiantes asignados',
+      descripcion:
+        'El sistema valida docente_id contra el grupo o trabajo para impedir la visualización de entregas ajenas.',
+    },
+    {
+      titulo: 'Retroalimentación dentro de la ventana de etapa',
+      descripcion:
+        'La plataforma permite emitir comentarios cuando la etapa respectiva está activa según la coordinación.',
+    },
+    {
+      titulo: 'Sin eliminación de entregas ni propuestas publicadas',
+      descripcion:
+        'No es posible eliminar registros ya publicados o con historial, garantizando trazabilidad institucional.',
+    },
+    {
+      titulo: 'Certificados reservados a coordinación',
+      descripcion:
+        'La emisión o validación final de certificados corresponde a Coordinación/Dirección; el rol docente no tiene acceso.',
+    },
+    {
+      titulo: 'Formatos y tamaño controlados al subir documentos',
+      descripcion:
+        'Solo se aceptan archivos PDF, DOCX o ZIP con peso máximo de 25 MB, validado tanto en frontend como backend.',
+    },
+    {
+      titulo: 'Rúbricas editables fuera de etapas activas',
+      descripcion:
+        'No se pueden modificar rúbricas durante una fase en curso; las actualizaciones deben realizarse antes de iniciar la etapa.',
+    },
+    {
+      titulo: 'Reportes circunscritos a estudiantes supervisados',
+      descripcion:
+        'Los paneles de datos muestran únicamente estadísticas de los estudiantes bajo su supervisión; no hay acceso a dashboards globales.',
+    },
+  ]);
 }


### PR DESCRIPTION
## Summary
- add an explicit list of restricciones for estudiantes in the alumno trabajo view
- render the restrictions section with contextual copy so the limitations are visible alongside thesis progress information
- style the new section to match the existing UI cards and ensure readability

## Testing
- npm run lint *(fails: missing script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd4fc8ddc8324902b9504a03f5b36)