### PR TITLE
feat: mostrar restricciones en perfil de alumno

### DIFF
--- a/frontend/src/app/features/alumno/perfil/alumno-perfil.component.css
+++ b/frontend/src/app/features/alumno/perfil/alumno-perfil.component.css
@@ -6,3 +6,60 @@
 .inp { border: 1px solid #dfe5ee; border-radius: 10px; padding: 8px 10px; min-width: 220px; }
 .link { color: #1976d2; font-weight: 800; text-decoration: none; }
 .list { margin: 0; padding-left: 16px; }
+
+.restricciones {
+  margin: 24px 0;
+  padding: 24px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+}
+
+.section-title {
+  margin: 0 0 12px;
+  color: #1a3e6a;
+}
+
+.restricciones-intro {
+  margin: 0 0 16px;
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.restricciones-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.restricciones-list li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: #fff;
+  border: 1px solid #dbe2f0;
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.restriccion-icon {
+  font-size: 20px;
+  margin-top: 2px;
+}
+
+.restriccion-texto h4 {
+  margin: 0 0 6px;
+  font-size: 0.95rem;
+  color: #1a3e6a;
+}
+
+.restriccion-texto p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}

--- a/frontend/src/app/features/alumno/perfil/alumno-perfil.component.html
+++ b/frontend/src/app/features/alumno/perfil/alumno-perfil.component.html
@@ -1,22 +1,5 @@
 <h2 class="ttl">Perfil de usuario</h2>
 
-<section class="restricciones" aria-labelledby="restricciones-alumno-titulo">
-  <h3 id="restricciones-alumno-titulo" class="section-title">Restricciones para estudiantes</h3>
-  <p class="restricciones-intro">
-    Estas reglas definen el comportamiento del sistema según tu progreso y los datos registrados. Se aplican de forma
-    automática para asegurar la trazabilidad del proceso de trabajo de título.
-  </p>
-  <ul class="restricciones-list">
-    <li *ngFor="let item of restricciones()">
-      <span class="restriccion-icon" aria-hidden="true">⚠️</span>
-      <div class="restriccion-texto">
-        <h4>{{ item.titulo }}</h4>
-        <p>{{ item.descripcion }}</p>
-      </div>
-    </li>
-  </ul>
-</section>
-
 <div class="grid">
   <div class="card">
     <h3>Información Personal</h3>
@@ -44,3 +27,20 @@
   <h3>Historial de Sesiones</h3>
   <ul class="list"><li>Último acceso: 23 de abril de 2024</li></ul>
 </div>
+
+<section class="restricciones" aria-labelledby="restricciones-alumno-titulo">
+  <h3 id="restricciones-alumno-titulo" class="section-title">Restricciones para estudiantes</h3>
+  <p class="restricciones-intro">
+    Estas reglas definen el comportamiento del sistema según tu progreso y los datos registrados. Se aplican de forma
+    automática para asegurar la trazabilidad del proceso de trabajo de título.
+  </p>
+  <ul class="restricciones-list">
+    <li *ngFor="let item of restricciones()">
+      <span class="restriccion-icon" aria-hidden="true">⚠️</span>
+      <div class="restriccion-texto">
+        <h4>{{ item.titulo }}</h4>
+        <p>{{ item.descripcion }}</p>
+      </div>
+    </li>
+  </ul>
+</section>

--- a/frontend/src/app/features/alumno/perfil/alumno-perfil.component.html
+++ b/frontend/src/app/features/alumno/perfil/alumno-perfil.component.html
@@ -1,5 +1,22 @@
 <h2 class="ttl">Perfil de usuario</h2>
 
+<section class="restricciones" aria-labelledby="restricciones-alumno-titulo">
+  <h3 id="restricciones-alumno-titulo" class="section-title">Restricciones para estudiantes</h3>
+  <p class="restricciones-intro">
+    Estas reglas definen el comportamiento del sistema según tu progreso y los datos registrados. Se aplican de forma
+    automática para asegurar la trazabilidad del proceso de trabajo de título.
+  </p>
+  <ul class="restricciones-list">
+    <li *ngFor="let item of restricciones()">
+      <span class="restriccion-icon" aria-hidden="true">⚠️</span>
+      <div class="restriccion-texto">
+        <h4>{{ item.titulo }}</h4>
+        <p>{{ item.descripcion }}</p>
+      </div>
+    </li>
+  </ul>
+</section>
+
 <div class="grid">
   <div class="card">
     <h3>Información Personal</h3>

--- a/frontend/src/app/features/alumno/perfil/alumno-perfil.component.spec.ts
+++ b/frontend/src/app/features/alumno/perfil/alumno-perfil.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AlumnoPerfilComponent } from './alumno-perfil.component';
+import { CurrentUserService } from '../../../shared/services/current-user.service';
+
+class CurrentUserServiceMock {
+  getProfile = jasmine.createSpy('getProfile').and.returnValue(null);
+}
+
+describe('AlumnoPerfilComponent', () => {
+  let fixture: ComponentFixture<AlumnoPerfilComponent>;
+  let component: AlumnoPerfilComponent;
+  let currentUserService: CurrentUserServiceMock;
+
+  beforeEach(async () => {
+    currentUserService = new CurrentUserServiceMock();
+
+    await TestBed.configureTestingModule({
+      imports: [AlumnoPerfilComponent],
+      providers: [{ provide: CurrentUserService, useValue: currentUserService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AlumnoPerfilComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should expose all restricciones with titulo and descripcion', () => {
+    const restricciones = component.restricciones();
+
+    expect(restricciones.length).toBe(10);
+    expect(restricciones.every((item) => item.titulo.trim().length > 0)).toBeTrue();
+    expect(restricciones.every((item) => item.descripcion.trim().length > 0)).toBeTrue();
+  });
+
+  it('should render each restriction in the template', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const renderedItems = Array.from(compiled.querySelectorAll('.restricciones-list li'));
+
+    expect(renderedItems.length).toBe(component.restricciones().length);
+
+    component.restricciones().forEach((item, index) => {
+      const title = renderedItems[index].querySelector('h4')?.textContent?.trim();
+      const description = renderedItems[index].querySelector('p')?.textContent?.trim();
+
+      expect(title).toBe(item.titulo);
+      expect(description).toBe(item.descripcion);
+    });
+  });
+});

--- a/frontend/src/app/features/alumno/perfil/alumno-perfil.component.ts
+++ b/frontend/src/app/features/alumno/perfil/alumno-perfil.component.ts
@@ -1,7 +1,12 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CurrentUserService, CurrentUserProfile } from '../../../shared/services/current-user.service';
+
+type RestriccionAlumno = {
+  titulo: string;
+  descripcion: string;
+};
 
 /** Perfil de usuario (ESTUDIANTE_13) */
 @Component({
@@ -16,6 +21,59 @@ export class AlumnoPerfilComponent implements OnInit {
 
   userProfile: CurrentUserProfile | null = null;
   tel = '';
+
+  readonly restricciones = signal<RestriccionAlumno[]>([
+    {
+      titulo: 'Una postulación activa por alumno',
+      descripcion:
+        'Si ya tienes una postulación en estado pendiente, en revisión, aceptada o rechazada con observaciones no podrás crear otra hasta que se cierre la actual.',
+    },
+    {
+      titulo: 'Sin edición de postulación tras el envío',
+      descripcion:
+        'Una vez enviada la postulación queda bloqueada. Solo vuelve a estar editable si el docente la marca como “observada”.',
+    },
+    {
+      titulo: 'Contenido filtrado por carrera',
+      descripcion:
+        'Solo verás docentes, propuestas y temáticas asociadas a tu carrera (career_id/codigo_carrera) para asegurar la pertinencia del proceso.',
+    },
+    {
+      titulo: 'Entregas solo en etapas habilitadas',
+      descripcion:
+        'Cada entrega se habilita únicamente si la etapa está activa y dentro de las fechas publicadas por la coordinación.',
+    },
+    {
+      titulo: 'Entregas bloqueadas tras confirmar',
+      descripcion:
+        'Al confirmar una entrega el archivo queda protegido; el botón de edición se oculta para mantener la integridad documental.',
+    },
+    {
+      titulo: 'Evaluaciones docentes cuando están publicadas',
+      descripcion:
+        'Los comentarios y resultados del docente solo se muestran cuando visible == true, tras la publicación de la retroalimentación.',
+    },
+    {
+      titulo: 'Agendamiento condicionado a profesor guía',
+      descripcion:
+        'Solo puedes agendar reuniones si cuentas con profesor guía asignado y el calendario se encuentra publicado (docente_asignado y calendario_publicado).',
+    },
+    {
+      titulo: 'Validación de archivos al subir',
+      descripcion:
+        'El sistema acepta únicamente archivos .pdf, .docx o .zip con un máximo de 25 MB, validado tanto en frontend como en backend.',
+    },
+    {
+      titulo: 'Formularios completos',
+      descripcion:
+        'Las solicitudes y entregas se pueden enviar únicamente si todos los campos obligatorios están completos; no se permiten formularios incompletos.',
+    },
+    {
+      titulo: 'Certificados tras finalizar el proceso',
+      descripcion:
+        'El certificado de aprobación se habilita solo si status_proceso == "finalizado" y evaluacion_final == "aprobada".',
+    },
+  ]);
 
   ngOnInit(): void {
     const profile = this.currentUserService.getProfile();

--- a/frontend/src/app/features/docente/dashboard/docente-dashboard.component.spec.ts
+++ b/frontend/src/app/features/docente/dashboard/docente-dashboard.component.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DocenteDashboardComponent } from './docente-dashboard.component';
+
+describe('DocenteDashboardComponent', () => {
+  let fixture: ComponentFixture<DocenteDashboardComponent>;
+  let component: DocenteDashboardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DocenteDashboardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocenteDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should expose every restriction with titulo and descripcion', () => {
+    const restricciones = component.restricciones();
+
+    expect(restricciones.length).toBe(13);
+    expect(restricciones.every((item) => item.titulo.trim().length > 0)).toBeTrue();
+    expect(restricciones.every((item) => item.descripcion.trim().length > 0)).toBeTrue();
+  });
+
+  it('should render each restriction item in the template', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const renderedItems = Array.from(compiled.querySelectorAll('.restricciones-list li'));
+
+    expect(renderedItems.length).toBe(component.restricciones().length);
+
+    component.restricciones().forEach((item, index) => {
+      const title = renderedItems[index].querySelector('h4')?.textContent?.trim();
+      const description = renderedItems[index].querySelector('p')?.textContent?.trim();
+
+      expect(title).toBe(item.titulo);
+      expect(description).toBe(item.descripcion);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- agregar listado de restricciones del estudiante al perfil de alumno
- cargar las descripciones de restricciones mediante señales en el componente
- aplicar estilos y estructura similares al panel docente para mantener consistencia visual

## Testing
- no tests were run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fe6fc746083248085ce4710453bd5)