### PR TITLE
feat(docente): mostrar reuniones agendadas en perfil

### DIFF
--- a/frontend/src/app/features/docente/perfil/docente-perfil.component.css
+++ b/frontend/src/app/features/docente/perfil/docente-perfil.component.css
@@ -124,3 +124,215 @@
   color: #008c4a;
   transform: translateY(-2px);
 }
+
+.calendar-card {
+  margin-top: 1.5rem;
+  gap: 1.25rem;
+}
+
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.calendar-subtitle {
+  margin: 0.25rem 0 0;
+  color: #5f6b7c;
+  font-size: 0.9rem;
+}
+
+.calendar-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.calendar-btn {
+  border: 1px solid #dfe5ee;
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.calendar-btn:hover {
+  background: #f3f6fb;
+}
+
+.calendar-label {
+  font-weight: 600;
+  color: #1a3e6a;
+  min-width: 145px;
+  text-align: center;
+}
+
+.calendar-state {
+  background: #f8f9fb;
+  border: 1px dashed #d6deeb;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  color: #3b4a5a;
+  font-size: 0.95rem;
+}
+
+.calendar-state.error {
+  background: #fff4f4;
+  border-color: #f4cccc;
+  color: #9d1b1b;
+}
+
+.calendar-body {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.calendar-dow {
+  text-align: center;
+  font-weight: 600;
+  color: #1a3e6a;
+  font-size: 0.85rem;
+}
+
+.calendar-day {
+  position: relative;
+  border: 1px solid #e1e7f0;
+  min-height: 72px;
+  background: #fff;
+  border-radius: 12px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 0.4rem;
+  transition: all 0.2s ease;
+}
+
+.calendar-day.empty {
+  cursor: default;
+  background: #f6f8fc;
+  border-style: dashed;
+}
+
+.calendar-day:not(.empty):hover {
+  border-color: #008c4a;
+  transform: translateY(-2px);
+}
+
+.calendar-day.today {
+  border-color: #1976d2;
+}
+
+.calendar-day.selected {
+  background: #008c4a;
+  color: #fff;
+  border-color: #008c4a;
+  box-shadow: 0 8px 20px rgba(0, 140, 74, 0.18);
+}
+
+.calendar-day.selected .day-indicator {
+  background: #fff;
+}
+
+.calendar-day.has-meetings:not(.selected) {
+  border-color: rgba(0, 140, 74, 0.35);
+}
+
+.day-number {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.day-indicator {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #008c4a;
+}
+
+.calendar-details {
+  background: #f8fafd;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid #e1e7f0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 100%;
+}
+
+.details-title {
+  margin: 0;
+  color: #1a3e6a;
+}
+
+.calendar-hint {
+  color: #5f6b7c;
+  font-size: 0.95rem;
+}
+
+.meeting-item {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  border: 1px solid #dde4f0;
+  box-shadow: 0 10px 20px rgba(26, 62, 106, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.meeting-time {
+  font-weight: 600;
+  color: #1a3e6a;
+}
+
+.meeting-title {
+  font-size: 1rem;
+}
+
+.meeting-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(0, 140, 74, 0.12);
+  color: #006834;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.chip.status {
+  background: rgba(25, 118, 210, 0.12);
+  color: #0b4c96;
+}
+
+.meeting-student,
+.meeting-notes {
+  color: #4a5565;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+  .calendar-body {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/features/docente/perfil/docente-perfil.component.html
+++ b/frontend/src/app/features/docente/perfil/docente-perfil.component.html
@@ -58,3 +58,75 @@
     <button class="btn-session" (click)="changePassword()">Cambiar contraseña</button>
   </div>
 </div>
+
+<div class="card calendar-card">
+  <div class="calendar-header">
+    <div>
+      <h3>Reuniones agendadas</h3>
+      <p class="calendar-subtitle">Selecciona un día para revisar los detalles de tus reuniones.</p>
+    </div>
+    <div class="calendar-controls">
+      <button type="button" class="calendar-btn" (click)="goToToday()">Hoy</button>
+      <button type="button" class="calendar-btn" (click)="goToPreviousMonth()">◀</button>
+      <span class="calendar-label">{{ calendarMonthLabel }}</span>
+      <button type="button" class="calendar-btn" (click)="goToNextMonth()">▶</button>
+    </div>
+  </div>
+
+  <div *ngIf="meetingsLoading" class="calendar-state">Cargando reuniones...</div>
+  <div *ngIf="meetingsError" class="calendar-state error">{{ meetingsError }}</div>
+
+  <div class="calendar-body" *ngIf="!meetingsLoading && !meetingsError">
+    <div class="calendar-grid">
+      <div class="calendar-dow" *ngFor="let dow of weekDays">{{ dow }}</div>
+      <ng-container *ngFor="let week of calendarWeeks">
+        <button
+          type="button"
+          *ngFor="let day of week"
+          class="calendar-day"
+          [class.empty]="day === 0"
+          [class.today]="isToday(day)"
+          [class.selected]="isSelected(day)"
+          [class.has-meetings]="hasMeetings(day)"
+          (click)="selectDay(day)"
+        >
+          <span *ngIf="day > 0" class="day-number">{{ day }}</span>
+          <span *ngIf="hasMeetings(day)" class="day-indicator"></span>
+        </button>
+      </ng-container>
+    </div>
+
+    <div class="calendar-details">
+      <ng-container *ngIf="selectedDay; else promptSelect">
+        <h4 class="details-title">{{ selectedDateLabel }}</h4>
+
+        <ng-container *ngIf="selectedMeetings.length > 0; else noMeetings">
+          <div class="meeting-item" *ngFor="let meeting of selectedMeetings">
+            <div class="meeting-time">{{ meeting.horaInicio }} – {{ meeting.horaTermino }}</div>
+            <div class="meeting-title">{{ meeting.motivo }}</div>
+            <div class="meeting-meta">
+              <span class="chip">{{ meeting.modalidad | titlecase }}</span>
+              <span class="chip status">Estado: {{ meeting.estado | titlecase }}</span>
+            </div>
+            <div class="meeting-student" *ngIf="meeting.alumno">Con: {{ meeting.alumno }}</div>
+            <div class="meeting-notes" *ngIf="meeting.observaciones">Notas: {{ meeting.observaciones }}</div>
+          </div>
+        </ng-container>
+      </ng-container>
+    </div>
+  </div>
+
+  <ng-template #promptSelect>
+    <div class="calendar-hint" *ngIf="hasAnyMeeting; else noMeetingsRegistered">
+      Selecciona un día del calendario para ver tus reuniones.
+    </div>
+  </ng-template>
+
+  <ng-template #noMeetings>
+    <div class="calendar-hint">No hay reuniones agendadas para esta fecha.</div>
+  </ng-template>
+
+  <ng-template #noMeetingsRegistered>
+    <div class="calendar-hint">Aún no registras reuniones agendadas.</div>
+  </ng-template>
+</div>

--- a/frontend/src/app/features/docente/perfil/docente-perfil.component.ts
+++ b/frontend/src/app/features/docente/perfil/docente-perfil.component.ts
@@ -2,10 +2,22 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CurrentUserService, CurrentUserProfile } from '../../../shared/services/current-user.service';
+import { ReunionesService, Reunion } from '../../../shared/services/reuniones.service';
 
 interface UserProfile extends CurrentUserProfile {
   ultimoAcceso?: string;
   contrasena?: string;
+}
+
+interface ReunionCalendario {
+  id: number;
+  motivo: string;
+  horaInicio: string;
+  horaTermino: string;
+  modalidad: string;
+  estado: string;
+  alumno: string | null;
+  observaciones: string | null;
 }
 
 
@@ -18,6 +30,7 @@ interface UserProfile extends CurrentUserProfile {
 })
 export class DocentePerfilComponent implements OnInit {
   private readonly currentUserService = inject(CurrentUserService);
+  private readonly reunionesService = inject(ReunionesService);
 
   isEditing = false;
 
@@ -37,6 +50,45 @@ export class DocentePerfilComponent implements OnInit {
   isLoading = false;
   isSaving = false;
 
+  meetingsLoading = false;
+  meetingsError: string | null = null;
+
+  private calendarMonth: Date;
+  private readonly today: Date;
+  private meetingsByDate: Record<string, ReunionCalendario[]> = {};
+  private calendarMatrix: number[][] = [];
+  private selectedDateKey: string | null = null;
+  selectedDay: number | null = null;
+
+  readonly weekDays = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
+  readonly monthNames = [
+    'Enero',
+    'Febrero',
+    'Marzo',
+    'Abril',
+    'Mayo',
+    'Junio',
+    'Julio',
+    'Agosto',
+    'Septiembre',
+    'Octubre',
+    'Noviembre',
+    'Diciembre',
+  ];
+
+  constructor() {
+    const now = new Date();
+    this.today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    this.calendarMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    this.selectedDay = now.getDate();
+    this.selectedDateKey = this.buildDateKey(
+      this.calendarMonth.getFullYear(),
+      this.calendarMonth.getMonth(),
+      this.selectedDay,
+    );
+    this.buildCalendarGrid();
+  }
+
   ngOnInit(): void {
     this.loadUserProfile();
   }
@@ -54,6 +106,10 @@ export class DocentePerfilComponent implements OnInit {
         ...profile,
       };
       this.editableProfile = { ...this.userProfile };
+
+      if (profile.id) {
+        this.loadMeetings(profile.id);
+      }
     } catch (error) {
       this.showErrorMessage('No se pudo cargar el perfil');
     } finally {
@@ -115,5 +171,217 @@ export class DocentePerfilComponent implements OnInit {
       this.editableProfile.telefono?.trim() ||
       this.editableProfile.contrasena?.trim()
     );
+  }
+
+  /* ===== Reuniones en calendario ===== */
+  get calendarWeeks(): number[][] {
+    return this.calendarMatrix;
+  }
+
+  get calendarMonthLabel(): string {
+    return `${this.monthNames[this.calendarMonth.getMonth()]} ${this.calendarMonth.getFullYear()}`;
+  }
+
+  get selectedMeetings(): ReunionCalendario[] {
+    if (!this.selectedDateKey) {
+      return [];
+    }
+    return this.meetingsByDate[this.selectedDateKey] ?? [];
+  }
+
+  get selectedDateLabel(): string {
+    if (!this.selectedDateKey) {
+      return '';
+    }
+    const [y, m, d] = this.selectedDateKey.split('-').map(Number);
+    const monthName = this.monthNames[m - 1]?.toLowerCase() ?? '';
+    return `${d} de ${monthName} de ${y}`;
+  }
+
+  get hasAnyMeeting(): boolean {
+    return Object.keys(this.meetingsByDate).length > 0;
+  }
+
+  goToPreviousMonth(): void {
+    this.calendarMonth = new Date(this.calendarMonth.getFullYear(), this.calendarMonth.getMonth() - 1, 1);
+    this.buildCalendarGrid();
+    this.selectedDay = null;
+    this.selectedDateKey = null;
+    this.ensureSelectionForCurrentMonth();
+  }
+
+  goToNextMonth(): void {
+    this.calendarMonth = new Date(this.calendarMonth.getFullYear(), this.calendarMonth.getMonth() + 1, 1);
+    this.buildCalendarGrid();
+    this.selectedDay = null;
+    this.selectedDateKey = null;
+    this.ensureSelectionForCurrentMonth();
+  }
+
+  goToToday(): void {
+    const now = new Date();
+    this.calendarMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    this.buildCalendarGrid();
+    this.selectedDay = null;
+    this.selectedDateKey = null;
+    this.ensureSelectionForCurrentMonth();
+  }
+
+  selectDay(day: number): void {
+    if (!day) {
+      return;
+    }
+    this.selectedDay = day;
+    this.selectedDateKey = this.buildDateKey(
+      this.calendarMonth.getFullYear(),
+      this.calendarMonth.getMonth(),
+      day,
+    );
+  }
+
+  isToday(day: number): boolean {
+    if (!day) {
+      return false;
+    }
+    return (
+      day === this.today.getDate() &&
+      this.calendarMonth.getMonth() === this.today.getMonth() &&
+      this.calendarMonth.getFullYear() === this.today.getFullYear()
+    );
+  }
+
+  isSelected(day: number): boolean {
+    return !!day && this.selectedDay === day;
+  }
+
+  hasMeetings(day: number): boolean {
+    if (!day) {
+      return false;
+    }
+    return this.hasMeetingsFor(day, this.calendarMonth.getFullYear(), this.calendarMonth.getMonth());
+  }
+
+  private loadMeetings(docenteId: number): void {
+    this.meetingsLoading = true;
+    this.meetingsError = null;
+    this.reunionesService.listarReuniones({ docente: docenteId }).subscribe({
+      next: (reuniones) => {
+        this.meetingsByDate = this.mapMeetings(reuniones);
+        this.meetingsLoading = false;
+        this.ensureSelectionForCurrentMonth();
+      },
+      error: (err) => {
+        console.error('No se pudieron cargar las reuniones del docente', err);
+        this.meetingsLoading = false;
+        const detail = err?.error?.detail;
+        this.meetingsError =
+          typeof detail === 'string'
+            ? detail
+            : 'No fue posible cargar las reuniones agendadas.';
+      },
+    });
+  }
+
+  private mapMeetings(reuniones: Reunion[]): Record<string, ReunionCalendario[]> {
+    const mapped: Record<string, ReunionCalendario[]> = {};
+    reuniones.forEach((reunion) => {
+      if (!reunion.fecha) {
+        return;
+      }
+      const key = reunion.fecha;
+      const entry: ReunionCalendario = {
+        id: reunion.id,
+        motivo: reunion.motivo,
+        horaInicio: reunion.horaInicio,
+        horaTermino: reunion.horaTermino,
+        modalidad: reunion.modalidad,
+        estado: reunion.estado,
+        alumno: reunion.alumno?.nombre ?? null,
+        observaciones: reunion.observaciones ?? null,
+      };
+      if (!mapped[key]) {
+        mapped[key] = [];
+      }
+      mapped[key].push(entry);
+    });
+
+    Object.values(mapped).forEach((items) => {
+      items.sort((a, b) => a.horaInicio.localeCompare(b.horaInicio));
+    });
+
+    return mapped;
+  }
+
+  private buildCalendarGrid(): void {
+    const year = this.calendarMonth.getFullYear();
+    const month = this.calendarMonth.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const firstWeekday = (firstDay.getDay() + 6) % 7; // lunes = 0
+    const totalDays = new Date(year, month + 1, 0).getDate();
+
+    const cells: number[] = [];
+    for (let i = 0; i < firstWeekday; i++) {
+      cells.push(0);
+    }
+    for (let d = 1; d <= totalDays; d++) {
+      cells.push(d);
+    }
+    while (cells.length % 7 !== 0) {
+      cells.push(0);
+    }
+
+    const weeks: number[][] = [];
+    for (let i = 0; i < cells.length; i += 7) {
+      weeks.push(cells.slice(i, i + 7));
+    }
+    this.calendarMatrix = weeks;
+  }
+
+  private ensureSelectionForCurrentMonth(): void {
+    const year = this.calendarMonth.getFullYear();
+    const month = this.calendarMonth.getMonth();
+
+    if (this.selectedDay) {
+      this.selectedDateKey = this.buildDateKey(year, month, this.selectedDay);
+      return;
+    }
+
+    if (year === this.today.getFullYear() && month === this.today.getMonth()) {
+      this.selectedDay = this.today.getDate();
+      this.selectedDateKey = this.buildDateKey(year, month, this.selectedDay);
+      return;
+    }
+
+    const firstWithMeeting = this.findFirstMeetingDay(year, month);
+    if (firstWithMeeting) {
+      this.selectedDay = firstWithMeeting;
+      this.selectedDateKey = this.buildDateKey(year, month, firstWithMeeting);
+    } else {
+      this.selectedDateKey = null;
+    }
+  }
+
+  private findFirstMeetingDay(year: number, month: number): number | null {
+    const totalDays = new Date(year, month + 1, 0).getDate();
+    for (let day = 1; day <= totalDays; day++) {
+      if (this.hasMeetingsFor(day, year, month)) {
+        return day;
+      }
+    }
+    return null;
+  }
+
+  private hasMeetingsFor(day: number, year: number, month: number): boolean {
+    if (!day) {
+      return false;
+    }
+    const key = this.buildDateKey(year, month, day);
+    return (this.meetingsByDate[key] ?? []).length > 0;
+  }
+
+  private buildDateKey(year: number, month: number, day: number): string {
+    const mm = String(month + 1).padStart(2, '0');
+    const dd = String(day).padStart(2, '0');
+    return `${year}-${mm}-${dd}`;
   }
 }


### PR DESCRIPTION
## Summary
- agregar un calendario interactivo al perfil docente para navegar por meses y seleccionar días
- obtener las reuniones del docente desde el servicio y mostrar los detalles de la fecha seleccionada
- aplicar estilos responsivos, indicadores de reunión y mensajes de estado en la tarjeta del calendario

## Testing
- npm run build *(falla por límites de budget de estilos existentes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179f8321188324ab5d941971e56340)