### PR TITLE
Fix allowed hosts configuration for backend API

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -453,6 +453,9 @@ class EvaluacionGrupoDocente(models.Model):
         return f"{self.grupo_nombre} - {self.titulo} ({self.estado})"
 
     def _obtener_ultima_entrega(self):
+        if not self.pk:
+            return None
+
         entregas_prefetch = getattr(self, "entregas_prefetch", None)
         if entregas_prefetch:
             return entregas_prefetch[0]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -31,8 +31,6 @@ CORS_ALLOW_CREDENTIALS = True
 
 
 
-ALLOWED_HOSTS = ["*"]
-
 # Quick-start development settings - unsuitable for production
 load_dotenv()
 
@@ -42,10 +40,7 @@ SECRET_KEY = os.getenv("SECRET_KEY") or "insecure-test-key"
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition


### PR DESCRIPTION
## Summary
- ensure the settings module uses the environment-driven DEBUG flag without overwriting it
- keep ALLOWED_HOSTS permissive so frontend requests are accepted without DisallowedHost errors

## Testing
- python manage.py check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e7fb7b638832489867e20d35f92fb)