### PR TITLE
Add comments and bulk sending for docente evaluations

### DIFF
--- a/backend/api/migrations/0030_evaluaciongrupodocente_comentario.py
+++ b/backend/api/migrations/0030_evaluaciongrupodocente_comentario.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0029_solicitudcartapractica_practica_correo_encargado"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluaciongrupodocente",
+            name="comentario",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/backend/api/migrations/0031_evaluaciongrupodocente_rubrica.py
+++ b/backend/api/migrations/0031_evaluaciongrupodocente_rubrica.py
@@ -1,5 +1,6 @@
 from django.db import migrations, models
-import backend.api.models
+
+from api.models import evaluacion_rubrica_upload_to
 
 
 class Migration(migrations.Migration):
@@ -12,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='evaluaciongrupodocente',
             name='rubrica',
-            field=models.FileField(blank=True, null=True, upload_to=backend.api.models.evaluacion_rubrica_upload_to),
+            field=models.FileField(blank=True, null=True, upload_to=evaluacion_rubrica_upload_to),
         ),
     ]

--- a/backend/api/migrations/0031_evaluaciongrupodocente_rubrica.py
+++ b/backend/api/migrations/0031_evaluaciongrupodocente_rubrica.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+import backend.api.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0030_evaluaciongrupodocente_comentario'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='evaluaciongrupodocente',
+            name='rubrica',
+            field=models.FileField(blank=True, null=True, upload_to=backend.api.models.evaluacion_rubrica_upload_to),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -419,6 +419,7 @@ class EvaluacionGrupoDocente(models.Model):
     )
     grupo_nombre = models.CharField(max_length=160)
     titulo = models.CharField(max_length=200)
+    comentario = models.TextField(blank=True, null=True)
     fecha = models.DateField(null=True, blank=True)
     estado = models.CharField(max_length=20, choices=ESTADOS, default="Pendiente")
     created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -880,6 +880,8 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
     archivo_nombre = serializers.CharField(source="archivo_nombre", read_only=True)
     archivo_tipo = serializers.SerializerMethodField()
 
+    MAX_ARCHIVO_MB = 25
+
     class Meta:
         model = EvaluacionEntregaAlumno
         fields = [
@@ -913,6 +915,18 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
             "archivo": {"write_only": True},
             "comentario": {"required": False, "allow_null": True, "allow_blank": True},
         }
+
+    def validate_archivo(self, value):
+        if not value:
+            return value
+
+        limite_bytes = self.MAX_ARCHIVO_MB * 1024 * 1024
+        if value.size > limite_bytes:
+            raise serializers.ValidationError(
+                f"El archivo supera el tamaño máximo permitido de {self.MAX_ARCHIVO_MB} MB."
+            )
+
+        return value
 
     def get_alumno(self, obj: EvaluacionEntregaAlumno):
         alumno = obj.alumno

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -955,6 +955,9 @@ class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
     grupo = serializers.SerializerMethodField()
     entregas = serializers.SerializerMethodField()
     ultima_entrega = serializers.SerializerMethodField()
+    rubrica_url = serializers.SerializerMethodField()
+    rubrica_nombre = serializers.SerializerMethodField()
+    rubrica_tipo = serializers.SerializerMethodField()
 
     class Meta:
         model = EvaluacionGrupoDocente
@@ -965,6 +968,10 @@ class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
             "grupo_nombre",
             "titulo",
             "comentario",
+            "rubrica",
+            "rubrica_url",
+            "rubrica_nombre",
+            "rubrica_tipo",
             "fecha",
             "estado",
             "created_at",
@@ -979,6 +986,9 @@ class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
             "updated_at",
             "estado",
             "grupo_nombre",
+            "rubrica_url",
+            "rubrica_nombre",
+            "rubrica_tipo",
             "entregas",
             "ultima_entrega",
         ]
@@ -1020,6 +1030,8 @@ class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
         data = data.copy()
         if data.get("fecha") in ("", None):
             data["fecha"] = None
+        if data.get("rubrica") in ("", None):
+            data["rubrica"] = None
         return super().to_internal_value(data)
 
     def validate(self, attrs):
@@ -1089,6 +1101,26 @@ class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
             context=self.context,
         )
         return serializer.data
+
+    def get_rubrica_url(self, obj: EvaluacionGrupoDocente) -> str | None:
+        if not obj.rubrica:
+            return None
+        request = self.context.get("request") if isinstance(self.context, dict) else None
+        url = obj.rubrica.url
+        if request:
+            return request.build_absolute_uri(url)
+        return url
+
+    def get_rubrica_nombre(self, obj: EvaluacionGrupoDocente) -> str | None:
+        if not obj.rubrica:
+            return None
+        return obj.rubrica_nombre or None
+
+    def get_rubrica_tipo(self, obj: EvaluacionGrupoDocente) -> str | None:
+        if not obj.rubrica:
+            return None
+        tipo, _ = mimetypes.guess_type(obj.rubrica.name)
+        return tipo or "application/octet-stream"
 
     def _obtener_entregas_prefetch(self, obj):
         entregas = getattr(obj, "entregas_prefetch", None)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -964,6 +964,7 @@ class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
             "tema",
             "grupo_nombre",
             "titulo",
+            "comentario",
             "fecha",
             "estado",
             "created_at",
@@ -1006,6 +1007,14 @@ class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
         if not titulo_limpio:
             raise serializers.ValidationError("Debes indicar el título de la evaluación.")
         return titulo_limpio
+
+    def validate_comentario(self, comentario: str | None) -> str:
+        comentario_limpio = (comentario or "").strip()
+        if not comentario_limpio:
+            raise serializers.ValidationError(
+                "Debes agregar un comentario para la evaluación."
+            )
+        return comentario_limpio
 
     def to_internal_value(self, data):
         data = data.copy()

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes, parser_classes
-from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.parsers import FormParser, MultiPartParser, JSONParser
 from rest_framework.permissions import AllowAny
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -2411,6 +2411,7 @@ class DocenteGruposActivosListView(generics.ListAPIView):
 
 class DocenteEvaluacionListCreateView(generics.ListCreateAPIView):
     serializer_class = EvaluacionGrupoDocenteSerializer
+    parser_classes = (MultiPartParser, FormParser, JSONParser)
 
     def get_queryset(self):
         queryset = (

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
@@ -87,6 +87,21 @@ h2.ttl{
 .info-row{ display:flex; gap:10px; align-items:center; margin:8px 0 12px; }
 .muted{ color:var(--muted); }
 
+.docente-detail{
+  display:grid;
+  gap:10px;
+  background:#fdfdff;
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:12px;
+  margin-bottom:12px;
+}
+.docente-head{ display:flex; justify-content:space-between; align-items:center; gap:8px; }
+.docente-head b{ color:#1a3e6a; }
+.docente-head .muted{ font-size:13px; }
+.docente-detail a{ color:#1e66c9; font-weight:700; text-decoration:none; }
+.docente-detail a:hover{ text-decoration:underline; }
+
 /* Instrucciones dentro del detalle */
 .instrucciones.detail{
   background:#f7fbff;

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -19,7 +19,12 @@
           </div>
           <p class="desc" *ngIf="e.descripcion">{{ e.descripcion }}</p>
           <div class="meta">
-            <span>Fecha límite: {{ e.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+            <ng-container *ngIf="e.fechaLimite; else noFechaPend">
+              <span>Fecha límite: {{ e.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+            </ng-container>
+            <ng-template #noFechaPend>
+              <span>Fecha límite no asignada</span>
+            </ng-template>
           </div>
         </article>
       </div>
@@ -39,7 +44,12 @@
           </div>
           <p class="desc" *ngIf="e.descripcion">{{ e.descripcion }}</p>
           <div class="meta">
-            <span>Fecha límite: {{ e.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+            <ng-container *ngIf="e.fechaLimite; else noFechaComp">
+              <span>Fecha límite: {{ e.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+            </ng-container>
+            <ng-template #noFechaComp>
+              <span>Fecha límite no asignada</span>
+            </ng-template>
             <!-- usar ?. porque ultimaEntrega puede no venir -->
             <span *ngIf="e.ultimaEntrega?.nota != null">
               • Nota: <b>{{ e.ultimaEntrega?.nota }}</b>
@@ -76,7 +86,43 @@
 
   <div class="info-row">
     <span class="chip" [ngClass]="estadoClase(ev.estado)">{{ ev.estado }}</span>
-    <span class="muted">Fecha límite: {{ ev.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+    <ng-container *ngIf="ev.fechaLimite; else noFechaDetalle">
+      <span class="muted">Fecha límite: {{ ev.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+    </ng-container>
+  </div>
+  <ng-template #noFechaDetalle>
+    <span class="muted">Fecha límite no asignada</span>
+  </ng-template>
+
+  <div class="docente-detail">
+    <div class="docente-head">
+      <b>Detalles del docente</b>
+      <span class="muted">Información que acompaña a la evaluación</span>
+    </div>
+
+    <div class="row">
+      <div><b>Comentario:</b></div>
+      <div>{{ ev.comentario || 'Sin comentarios adicionales.' }}</div>
+    </div>
+
+    <div class="row">
+      <div><b>Rúbrica:</b></div>
+      <div>
+        <ng-container *ngIf="ev.rubricaUrl && ev.rubricaNombre; else sinRubrica">
+          <a
+            [href]="ev.rubricaUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            📎 {{ ev.rubricaNombre }}
+          </a>
+          <small class="muted" *ngIf="ev.rubricaTipo">({{ ev.rubricaTipo }})</small>
+        </ng-container>
+        <ng-template #sinRubrica>
+          Sin rúbrica adjunta.
+        </ng-template>
+      </div>
+    </div>
   </div>
 
   <!-- Si pendiente -> botón subir -->

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -27,9 +27,13 @@ interface Evaluacion {
   id: number;
   titulo: string;
   descripcion?: string;
+  comentario?: string | null;
   fechaLimite: string | Date | null;
   estado: EstadoEval;
   tipo: 'informe' | 'presentación' | 'anexo' | string;
+  rubricaUrl?: string | null;
+  rubricaNombre?: string | null;
+  rubricaTipo?: string | null;
   ultimaEntrega?: Entrega | null;
 }
 
@@ -134,9 +138,13 @@ export class AlumnoEntregaComponent implements OnInit {
       id: dto.id,
       titulo: dto.titulo,
       descripcion: undefined,
+      comentario: dto.comentario,
       fechaLimite: this.parseFecha(dto.fecha),
       estado: this.mapEstado(dto, ultima),
       tipo: this.inferirTipo(dto.titulo),
+      rubricaUrl: dto.rubrica_url,
+      rubricaNombre: dto.rubrica_nombre,
+      rubricaTipo: dto.rubrica_tipo,
       ultimaEntrega: ultima ? this.mapEntregaDto(ultima) : null,
     };
   }

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -304,14 +304,31 @@ export class AlumnoEntregaComponent implements OnInit {
   onDrop(ev: DragEvent) {
     ev.preventDefault();
     this._dragging.set(false);
-    const f = ev.dataTransfer?.files?.[0];
-    if (f) this._archivo.set(f);
+    const f = ev.dataTransfer?.files?.[0] ?? null;
+    this.asignarArchivo(f);
   }
 
   onFilePick(ev: Event) {
     const input = ev.target as HTMLInputElement;
     const f = input.files?.[0] || null;
-    this._archivo.set(f);
+    this.asignarArchivo(f);
+  }
+
+  private asignarArchivo(file: File | null) {
+    if (!file) {
+      this._archivo.set(null);
+      return;
+    }
+
+    const sizeMB = Math.round((file.size / (1024 * 1024)) * 10) / 10;
+    if (sizeMB > this.maxMB) {
+      this._errorMsg.set(`El archivo supera el máximo de ${this.maxMB} MB.`);
+      this._archivo.set(null);
+      return;
+    }
+
+    this._errorMsg.set(null);
+    this._archivo.set(file);
   }
 
   submitUpload() {
@@ -378,8 +395,16 @@ export class AlumnoEntregaComponent implements OnInit {
             this._errorMsg.set(detalle.archivo[0]);
             return;
           }
+          if (detalle?.alumno?.[0]) {
+            this._errorMsg.set(detalle.alumno[0]);
+            return;
+          }
           if (detalle?.evaluacion?.[0]) {
             this._errorMsg.set(detalle.evaluacion[0]);
+            return;
+          }
+          if (typeof detalle?.detail === 'string') {
+            this._errorMsg.set(detalle.detail);
             return;
           }
           this._errorMsg.set('No pudimos subir tu entrega. Intenta nuevamente.');

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -201,6 +201,15 @@ export class AlumnoEntregaComponent implements OnInit {
       return null;
     }
 
+    // When the backend sends only a date (YYYY-MM-DD), construct the date at the
+    // end of the local day so it isn't shifted to the previous day by timezone
+    // conversion. Otherwise, fall back to native parsing for full timestamps.
+    const soloFecha = /^\d{4}-\d{2}-\d{2}$/;
+    if (soloFecha.test(valor)) {
+      const [anio, mes, dia] = valor.split('-').map((v) => Number(v));
+      return new Date(anio, mes - 1, dia, 23, 59, 0, 0);
+    }
+
     const fecha = new Date(valor);
     return Number.isNaN(fecha.getTime()) ? null : fecha;
   }

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.service.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.service.ts
@@ -26,10 +26,14 @@ export interface EvaluacionGrupoDto {
   tema: number | null;
   grupo_nombre: string;
   titulo: string;
+  comentario: string | null;
   fecha: string | null;
   estado: string;
   created_at: string;
   updated_at: string;
+  rubrica_url: string | null;
+  rubrica_nombre: string | null;
+  rubrica_tipo: string | null;
   grupo: {
     id: number;
     nombre: string;

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.css
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.css
@@ -33,12 +33,18 @@
 }
 
 .field input,
-.field select {
+.field select,
+.field textarea {
   border: 1px solid #c7d5eb;
   border-radius: 10px;
   padding: 10px 12px;
   font: inherit;
   background: #fff;
+  resize: vertical;
+}
+
+.textarea-field {
+  grid-column: 1 / -1;
 }
 
 .field-hint {
@@ -89,6 +95,12 @@
 .status-preview.evaluada {
   background: #def7ec;
   color: #047857;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .btn {
@@ -178,6 +190,12 @@
   flex-wrap: wrap;
   color: #4b5563;
   font-size: 13px;
+}
+
+.comentario {
+  margin: 6px 0 0;
+  color: #1f2937;
+  font-size: 14px;
 }
 
 .empty {

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.css
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.css
@@ -131,6 +131,18 @@
   background: #0f2f52;
 }
 
+.btn.link {
+  background: transparent;
+  color: #1a3e6a;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.btn.link:hover {
+  background: transparent;
+  color: #0f2f52;
+}
+
 .groups {
   display: grid;
   gap: 16px;

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.html
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.html
@@ -35,6 +35,16 @@
         (input)="evaluacionTitulo.set(($any($event.target)).value)"
       />
     </label>
+    <label class="field textarea-field">
+      <span>Comentario de la evaluación</span>
+      <textarea
+        rows="3"
+        placeholder="Describe brevemente los criterios o indicaciones de la evaluación"
+        [value]="evaluacionComentario()"
+        (input)="evaluacionComentario.set(($any($event.target)).value)"
+      ></textarea>
+      <small class="field-hint">Este comentario se enviará junto con la evaluación.</small>
+    </label>
     <label class="field">
       <span>Fecha (opcional)</span>
       <input
@@ -50,19 +60,36 @@
       </div>
     </div>
   </div>
-  <button
-    class="btn"
-    type="submit"
-    [disabled]="
-      enviando() ||
-      cargandoGruposActivos() ||
-      !gruposActivos().length ||
-      !grupoSeleccionadoId() ||
-      !evaluacionTitulo().trim()
-    "
-  >
-    {{ enviando() ? 'Guardando…' : 'Agregar evaluación' }}
-  </button>
+  <div class="form-actions">
+    <button
+      class="btn"
+      type="submit"
+      [disabled]="
+        enviando() ||
+        cargandoGruposActivos() ||
+        !gruposActivos().length ||
+        !grupoSeleccionadoId() ||
+        !evaluacionTitulo().trim() ||
+        !evaluacionComentario().trim()
+      "
+    >
+      {{ enviando() ? 'Guardando…' : 'Agregar evaluación' }}
+    </button>
+    <button
+      type="button"
+      class="btn secondary"
+      (click)="enviarEvaluacionMasiva()"
+      [disabled]="
+        enviando() ||
+        cargandoGruposActivos() ||
+        !gruposActivos().length ||
+        !evaluacionTitulo().trim() ||
+        !evaluacionComentario().trim()
+      "
+    >
+      {{ enviando() ? 'Enviando…' : 'Enviar a todos los grupos' }}
+    </button>
+  </div>
 </form>
 
 <p class="error" *ngIf="error()">{{ error() }}</p>
@@ -83,6 +110,9 @@
                 >Fecha: {{ evaluacion.fecha | date: 'dd/MM/yyyy' }}</span
               >
               <span>Estado: {{ evaluacion.estado }}</span>
+            </p>
+            <p class="comentario" *ngIf="evaluacion.comentario">
+              Comentario: {{ evaluacion.comentario }}
             </p>
           </li>
         </ul>

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.html
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.component.html
@@ -46,6 +46,18 @@
       <small class="field-hint">Este comentario se enviará junto con la evaluación.</small>
     </label>
     <label class="field">
+      <span>Rúbrica (opcional)</span>
+      <input
+        #rubricaInput
+        type="file"
+        accept=".pdf,.doc,.docx,.xlsx,.xls,.png,.jpg,.jpeg"
+        (change)="onRubricaSeleccionada($event)"
+        [disabled]="enviando()"
+      />
+      <small class="field-hint">Adjunta la rúbrica o pauta que usarás en la evaluación.</small>
+      <small class="field-hint" *ngIf="evaluacionRubrica()">Archivo seleccionado: {{ evaluacionRubrica()?.name }}</small>
+    </label>
+    <label class="field">
       <span>Fecha (opcional)</span>
       <input
         type="date"
@@ -114,6 +126,14 @@
             <p class="comentario" *ngIf="evaluacion.comentario">
               Comentario: {{ evaluacion.comentario }}
             </p>
+            <button
+              class="btn link"
+              type="button"
+              *ngIf="evaluacion.rubricaUrl"
+              (click)="descargarRubrica(evaluacion.rubricaUrl)"
+            >
+              Ver rúbrica ({{ evaluacion.rubricaNombre }})
+            </button>
           </li>
         </ul>
       </section>

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
@@ -26,6 +26,7 @@ export interface EvaluacionGrupoDto {
   tema: number | null;
   grupo_nombre: string;
   titulo: string;
+  comentario: string | null;
   fecha: string | null;
   estado: string;
   created_at: string;
@@ -43,6 +44,7 @@ export type CrearEvaluacionPayload = {
   docente?: number | null;
   tema: number;
   titulo: string;
+  comentario: string;
   fecha?: string | null;
 };
 
@@ -74,6 +76,7 @@ export class DocenteEvaluacionesService {
     const body: Record<string, unknown> = {
       tema: payload.tema,
       titulo: payload.titulo,
+      comentario: payload.comentario,
     };
 
     if (payload.fecha) {

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
@@ -27,6 +27,9 @@ export interface EvaluacionGrupoDto {
   grupo_nombre: string;
   titulo: string;
   comentario: string | null;
+  rubrica_url: string | null;
+  rubrica_nombre: string | null;
+  rubrica_tipo: string | null;
   fecha: string | null;
   estado: string;
   created_at: string;
@@ -45,6 +48,7 @@ export type CrearEvaluacionPayload = {
   tema: number;
   titulo: string;
   comentario: string;
+  rubrica?: File | null;
   fecha?: string | null;
 };
 
@@ -73,23 +77,46 @@ export class DocenteEvaluacionesService {
   }
 
   crear(payload: CrearEvaluacionPayload): Observable<EvaluacionGrupoDto> {
-    const body: Record<string, unknown> = {
-      tema: payload.tema,
-      titulo: payload.titulo,
-      comentario: payload.comentario,
-    };
+    const usarFormData = Boolean(payload.rubrica instanceof File);
+
+    if (!usarFormData) {
+      const body: Record<string, unknown> = {
+        tema: payload.tema,
+        titulo: payload.titulo,
+        comentario: payload.comentario,
+      };
+
+      if (payload.fecha) {
+        body['fecha'] = payload.fecha;
+      } else if (payload.fecha === null) {
+        body['fecha'] = null;
+      }
+
+      if (payload.docente != null) {
+        body['docente'] = payload.docente;
+      }
+
+      return this.http.post<EvaluacionGrupoDto>(this.baseUrl, body);
+    }
+
+    const form = new FormData();
+    form.append('tema', String(payload.tema));
+    form.append('titulo', payload.titulo);
+    form.append('comentario', payload.comentario);
 
     if (payload.fecha) {
-      body['fecha'] = payload.fecha;
-    } else if (payload.fecha === null) {
-      body['fecha'] = null;
+      form.append('fecha', payload.fecha);
     }
 
     if (payload.docente != null) {
-      body['docente'] = payload.docente;
+      form.append('docente', String(payload.docente));
     }
 
-    return this.http.post<EvaluacionGrupoDto>(this.baseUrl, body);
+    if (payload.rubrica instanceof File) {
+      form.append('rubrica', payload.rubrica);
+    }
+
+    return this.http.post<EvaluacionGrupoDto>(this.baseUrl, form);
   }
 
   listarGruposActivos(docenteId?: number | null): Observable<GrupoActivoDto[]> {


### PR DESCRIPTION
## Summary
- add a mandatory comment field to docente evaluations, including validation and migration
- expose the comment in the docente evaluations UI with updated styling and reset logic
- add a bulk send option to create the evaluation across all active groups at once

## Testing
- npm run lint *(fails: script not defined in frontend package.json)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f40c336788324af5fb742f4b59172)