### PR TITLE
Integrate tema service updates and assigned topic UI

### DIFF
--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -8,6 +8,56 @@
     </div>
   </ng-template>
 
+  <div class="tema-asignado" *ngIf="nivelesDisponibles().length">
+    <ng-container *ngIf="temaAsignadoCargando(); else temaAsignadoEstado">
+      <div class="alert info">Cargando tu tema asignado...</div>
+    </ng-container>
+
+    <ng-template #temaAsignadoEstado>
+      <div *ngIf="temaAsignadoError(); else temaAsignadoContenido" class="alert warn">
+        {{ temaAsignadoError() }}
+      </div>
+    </ng-template>
+
+    <ng-template #temaAsignadoContenido>
+      <ng-container *ngIf="temaAsignado() as tema; else sinTemaAsignado">
+        <div class="tema-asignado-card">
+          <div class="tema-asignado-head">
+            <div>
+              <p class="tema-asignado-carrera">{{ tema.carrera }}</p>
+              <h3 class="tema-asignado-titulo">{{ tema.titulo }}</h3>
+              <p class="tema-asignado-descripcion">{{ tema.descripcion }}</p>
+            </div>
+            <div class="chips right">
+              <span class="chip">Cupos: {{ tema.cupos }}</span>
+              <span class="chip ghost" *ngIf="tema.cuposDisponibles != null">Disponibles: {{ tema.cuposDisponibles }}</span>
+            </div>
+          </div>
+
+          <div class="tema-asignado-profesor" *ngIf="profesorAsignado() as profesor">
+            <span class="tema-asignado-profesor-label">Profesor guía:</span>
+            <span class="tema-asignado-profesor-nombre">{{ profesor.nombre }}</span>
+            <span class="tema-asignado-profesor-extra" *ngIf="profesor.carrera">({{ profesor.carrera }})</span>
+          </div>
+
+          <div class="tema-asignado-integrantes" *ngIf="temaAsignadoIntegrantes().length">
+            <p class="tema-asignado-profesor-label">Integrantes:</p>
+            <ul>
+              <li *ngFor="let integrante of temaAsignadoIntegrantes()">
+                {{ integrante.nombre }} <span *ngIf="integrante.esResponsable">· Responsable</span>
+              </li>
+            </ul>
+          </div>
+
+          <div class="upload-actions">
+            <a class="btn link" routerLink="/alumno/temas">Gestionar tema</a>
+            <button class="btn primary" *ngIf="puedeGestionarCupos()" routerLink="/alumno/temas">Gestionar cupos</button>
+          </div>
+        </div>
+      </ng-container>
+    </ng-template>
+  </div>
+
   <ng-container *ngIf="nivelesDisponibles().length; else sinNiveles">
     <div class="tabs">
       <button *ngIf="tieneNivel('i')" [class.active]="nivelSeleccionado() === 'i'" (click)="seleccionarNivel('i')">
@@ -36,7 +86,7 @@
         <h3>{{ destacada.encabezado }}</h3>
         <span class="badge" [ngClass]="destacada.estado">{{ destacada.estadoEtiqueta }}</span>
       </div>
-      
+
       <div class="upload-content">
         <div class="upload-info">
           <p class="upload-title">{{ destacada.nombre }}</p>
@@ -45,7 +95,7 @@
             <button class="btn primary" routerLink="/alumno/entrega">Gestionar entregas</button>
           </div>
         </div>
-        
+
         <div class="chips right">
           <span class="chip">{{ destacada.fecha }}</span>
           <span class="chip ghost" *ngIf="destacada.proximoPaso">Próximo paso: {{ destacada.proximoPaso }}</span>

--- a/frontend/src/app/features/docente/temas/tema.service.ts
+++ b/frontend/src/app/features/docente/temas/tema.service.ts
@@ -1,37 +1,8 @@
-import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
-
-export interface TemaDisponible {
-  id: number;
-  titulo: string;
-  carrera: string;
-  descripcion: string;
-  requisitos: string[];
-  cupos: number;
-  created_at: string;
-  created_by: number | null;
-}
-
-export type CrearTemaPayload = Omit<TemaDisponible, 'id' | 'created_at' | 'created_by'> & {
-  created_by?: number | null;
-};
-
-@Injectable({ providedIn: 'root' })
-export class TemaService {
-  private readonly baseUrl = 'http://localhost:8000/api/temas/';
-
-  constructor(private http: HttpClient) {}
-
-  getTemas(): Observable<TemaDisponible[]> {
-    return this.http.get<TemaDisponible[]>(this.baseUrl);
-  }
-
-  crearTema(payload: CrearTemaPayload): Observable<TemaDisponible> {
-    return this.http.post<TemaDisponible>(this.baseUrl, payload);
-  }
-
-  eliminarTema(id: number): Observable<void> {
-    return this.http.delete<void>(`${this.baseUrl}${id}/`);
-  }
-}
+export {
+  CrearTemaPayload,
+  TemaDisponible,
+  TemaInscripcionActiva,
+  TemaQueryParams,
+  TemaService,
+  TemaUsuarioBasico,
+} from '../trabajolist/tema.service';

--- a/frontend/src/app/features/docente/trabajolist/tema.service.ts
+++ b/frontend/src/app/features/docente/trabajolist/tema.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface TemaUsuarioBasico {
+  id?: number | null;
+  nombre?: string | null;
+  rol?: string | null;
+  carrera?: string | null;
+}
+
+export interface TemaInscripcionActiva {
+  id: number;
+  nombre: string;
+  correo: string;
+  carrera: string | null;
+  rut: string | null;
+  telefono: string | null;
+  reservadoEn: string;
+  esResponsable?: boolean;
+}
+
+export interface TemaDisponible {
+  id: number;
+  titulo: string;
+  carrera: string;
+  descripcion: string;
+  requisitos?: string[];
+  cupos: number;
+  cuposDisponibles?: number;
+  created_at?: string;
+  created_by?: number | null;
+  rama?: string | null;
+  creadoPor?: TemaUsuarioBasico | null;
+  docenteACargo?: TemaUsuarioBasico | null;
+  docente_responsable?: number | null;
+  inscripcionesActivas?: TemaInscripcionActiva[];
+  tieneCupoPropio?: boolean;
+}
+
+export type CrearTemaPayload = Omit<
+  TemaDisponible,
+  'id' | 'created_at' | 'created_by' | 'inscripcionesActivas' | 'tieneCupoPropio'
+> & { created_by?: number | null };
+
+export interface TemaQueryParams {
+  usuarioId?: number;
+  alumnoId?: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TemaService {
+  private readonly baseUrl = '/api/temas/';
+
+  constructor(private http: HttpClient) {}
+
+  getTemas(params?: TemaQueryParams): Observable<TemaDisponible[]> {
+    const httpParams = this.buildParams(params);
+    return this.http.get<TemaDisponible[]>(this.baseUrl, { params: httpParams });
+  }
+
+  obtenerTema(id: number, params?: TemaQueryParams): Observable<TemaDisponible> {
+    const httpParams = this.buildParams(params);
+    return this.http.get<TemaDisponible>(`${this.baseUrl}${id}/`, { params: httpParams });
+  }
+
+  crearTema(payload: CrearTemaPayload): Observable<TemaDisponible> {
+    return this.http.post<TemaDisponible>(this.baseUrl, payload);
+  }
+
+  eliminarTema(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}${id}/`);
+  }
+
+  pedirTema(temaId: number, alumnoId: number): Observable<TemaDisponible> {
+    return this.http.post<TemaDisponible>(`${this.baseUrl}${temaId}/postular/`, {
+      alumnoId,
+    });
+  }
+
+  asignarCompaneros(temaId: number, alumnoId: number, correos: string[]): Observable<TemaDisponible> {
+    return this.http.post<TemaDisponible>(`${this.baseUrl}${temaId}/companeros/`, {
+      alumnoId,
+      correos,
+    });
+  }
+
+  private buildParams(params?: TemaQueryParams): HttpParams {
+    let httpParams = new HttpParams();
+    if (params?.usuarioId != null) {
+      httpParams = httpParams.set('usuarioId', params.usuarioId);
+    }
+    if (params?.alumnoId != null) {
+      httpParams = httpParams.set('alumnoId', params.alumnoId);
+    }
+    return httpParams;
+  }
+}


### PR DESCRIPTION
## Summary
- add expanded tema service under docente/trabajolist and re-export from the temas folder
- show alumno's tema asignado state with loading/error handling in the trabajo view
- keep existing tabs and entrega flows while wiring shared service types

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c1c1c72883248300f74e2f88d735)