### PR TITLE
Mostrar entregas de evaluaciones en Trabajo de Título

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -954,6 +954,22 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
         return tipo or "application/octet-stream"
 
 
+class DocenteEvaluacionEntregaUpdateSerializer(EvaluacionEntregaAlumnoSerializer):
+    class Meta(EvaluacionEntregaAlumnoSerializer.Meta):
+        read_only_fields = [
+            "id",
+            "evaluacion",
+            "alumno",
+            "archivo_url",
+            "archivo_nombre",
+            "archivo_tipo",
+            "creado_en",
+            "actualizado_en",
+            "archivo",
+            "titulo",
+        ]
+
+
 class EvaluacionGrupoDocenteSerializer(serializers.ModelSerializer):
     docente = serializers.PrimaryKeyRelatedField(
         queryset=Usuario.objects.filter(rol="docente"),

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -24,6 +24,7 @@ from .views import (
     eliminar_documento_practica,
     gestionar_firma_coordinador_practica,
     DocenteEvaluacionListCreateView,
+    DocenteEvaluacionEntregaUpdateView,
     DocenteGruposActivosListView,
     AlumnoEvaluacionListView,
     AlumnoEvaluacionEntregaListCreateView,
@@ -153,5 +154,10 @@ urlpatterns = [
         "alumnos/evaluaciones/<int:pk>/entregas/",
         AlumnoEvaluacionEntregaListCreateView.as_view(),
         name="alumno-evaluacion-entregas",
+    ),
+    path(
+        "docentes/evaluaciones/entregas/<int:pk>/",
+        DocenteEvaluacionEntregaUpdateView.as_view(),
+        name="docente-evaluacion-actualizar-entrega",
     ),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -70,6 +70,7 @@ from .serializers import (
     ReunionCerrarSerializer,
     TemaDisponibleSerializer,
     UsuarioResumenSerializer,
+    DocenteEvaluacionEntregaUpdateSerializer,
     EvaluacionGrupoDocenteSerializer,
     EvaluacionEntregaAlumnoSerializer,
     DocenteGrupoActivoSerializer,
@@ -2568,6 +2569,11 @@ class AlumnoEvaluacionEntregaListCreateView(generics.ListCreateAPIView):
         except (TypeError, ValueError):
             return None
         return alumno_id
+
+
+class DocenteEvaluacionEntregaUpdateView(generics.UpdateAPIView):
+    serializer_class = DocenteEvaluacionEntregaUpdateSerializer
+    queryset = EvaluacionEntregaAlumno.objects.select_related("evaluacion", "alumno")
 
 
 def _docente_en_preferencias(docente_id: int, preferencias) -> bool:

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
@@ -62,6 +62,7 @@ export interface GrupoActivoDto {
 export class DocenteEvaluacionesService {
   private readonly baseUrl = 'http://localhost:8000/api/docentes/evaluaciones/';
   private readonly gruposActivosUrl = 'http://localhost:8000/api/docentes/grupos/activos/';
+  private readonly entregasUrl = 'http://localhost:8000/api/docentes/evaluaciones/entregas/';
 
   constructor(private readonly http: HttpClient) {}
 
@@ -128,5 +129,12 @@ export class DocenteEvaluacionesService {
 
     const options = params.keys().length ? { params } : {};
     return this.http.get<GrupoActivoDto[]>(this.gruposActivosUrl, options);
+  }
+
+  actualizarEntrega(
+    entregaId: number,
+    payload: Pick<EvaluacionEntregaDto, 'nota' | 'comentario' | 'estado_revision'>,
+  ): Observable<EvaluacionEntregaDto> {
+    return this.http.patch<EvaluacionEntregaDto>(`${this.entregasUrl}${entregaId}/`, payload);
   }
 }

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.css
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.css
@@ -237,6 +237,23 @@ select {
 }
 textarea { min-height:130px; resize:vertical; }
 
+.file-picker {
+  display:flex;
+  align-items:center;
+  gap:10px;
+  padding:10px 12px;
+  border:1px dashed #dbe3ee;
+  border-radius:10px;
+  background:#fbfdff;
+  cursor:pointer;
+}
+
+.file-picker input[type="file"] {
+  display:none;
+}
+
+.file-picker span { font-weight:700; color:#1a3e6a; }
+
 input[type="text"]:focus,
 input[type="number"]:focus,
 textarea:focus,
@@ -344,6 +361,10 @@ select:focus {
 .hit-descr, .hit-meta { margin:4px 0 8px; }
 .hit-actions { display:flex; gap:10px; }
 .hit-resumen { margin-top:10px; border-top:1px dashed #e5edf7; padding-top:10px; color:#1f2937; }
+.hit-files { display:flex; flex-direction:column; gap:6px; margin-top:10px; }
+.file-chip { display:inline-flex; align-items:center; gap:8px; padding:8px 10px; background:#f4f7fb; border-radius:10px; border:1px solid #e2e8f0; width:fit-content; }
+.file-chip a { color:#1a3e6a; font-weight:700; text-decoration:none; }
+.file-chip a:hover { text-decoration:underline; }
 
 /* ===== Filtros ===== */
 .filtros-bar {

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
@@ -164,9 +164,13 @@
         <textarea [(ngModel)]="comentariosInput" name="comentarios" placeholder="Opcional, observaciones de la evaluación"></textarea>
       </div>
 
+      <p class="error" *ngIf="errorEvaluacion">{{ errorEvaluacion }}</p>
+
       <div class="actions full">
         <button type="button" class="btn light" (click)="cerrarEvalModal()">Cancelar</button>
-        <button type="submit" class="btn primary" [disabled]="notaInput==null">Guardar evaluación</button>
+        <button type="submit" class="btn primary" [disabled]="notaInput==null || guardandoEvaluacion">
+          {{ guardandoEvaluacion ? 'Guardando…' : 'Guardar evaluación' }}
+        </button>
       </div>
     </form>
   </div>

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
@@ -94,6 +94,23 @@
               <div class="hit-resumen" *ngIf="e.expanded">
                 <p class="muted"><b>Comentarios:</b></p>
                 <p>{{ e.comentarios }}</p>
+                <div class="hit-files" *ngIf="e.rubricaUrl || e.informeUrl">
+                  <p class="muted"><b>Archivos adjuntos</b></p>
+                  <div class="file-chip" *ngIf="e.rubricaUrl">
+                    📎
+                    <a [href]="e.rubricaUrl" target="_blank" rel="noopener noreferrer">
+                      {{ e.rubricaNombre || 'Rúbrica' }}
+                    </a>
+                    <small class="muted" *ngIf="e.rubricaTipo">({{ e.rubricaTipo }})</small>
+                  </div>
+                  <div class="file-chip" *ngIf="e.informeUrl">
+                    📝
+                    <a [href]="e.informeUrl" target="_blank" rel="noopener noreferrer">
+                      {{ e.informeNombre || 'Informe corregido' }}
+                    </a>
+                    <small class="muted" *ngIf="e.informeTipo">({{ e.informeTipo }})</small>
+                  </div>
+                </div>
               </div>
             </div>
           </ng-container>
@@ -122,6 +139,24 @@
       <div class="field">
         <label>Nota (1.0 a 7.0) <span class="req">*</span></label>
         <input type="number" min="1" max="7" step="0.1" [(ngModel)]="notaInput" name="nota" required />
+      </div>
+
+      <div class="field">
+        <label>Rúbrica con puntaje</label>
+        <label class="file-picker">
+          <input type="file" accept="application/pdf,.pdf" (change)="onRubricaSeleccionada($event)" />
+          <span>{{ rubricaArchivo?.name || 'Subir rúbrica (PDF)' }}</span>
+        </label>
+        <small class="muted">Adjunta la rúbrica completa con el desglose de puntaje.</small>
+      </div>
+
+      <div class="field">
+        <label>Informe con correcciones</label>
+        <label class="file-picker">
+          <input type="file" (change)="onInformeSeleccionado($event)" />
+          <span>{{ informeArchivo?.name || 'Subir informe corregido' }}</span>
+        </label>
+        <small class="muted">Archivo con las observaciones y correcciones para el alumno.</small>
       </div>
 
       <div class="field full">

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.html
@@ -43,6 +43,9 @@
         <div class="muted">{{ grupoSeleccionado?.integrantes?.join(' / ') }}</div>
       </div>
 
+      <p class="muted" *ngIf="cargandoEntregas">Cargando entregas…</p>
+      <p class="error" *ngIf="!cargandoEntregas && errorEntregas">{{ errorEntregas }}</p>
+
       <div class="filtros-bar">
         <select [(ngModel)]="filtroTipo">
           <option *ngFor="let t of tiposEntrega" [value]="t">{{ t }}</option>
@@ -50,7 +53,7 @@
         <input type="text" [(ngModel)]="filtroBusqueda" placeholder="Buscar entrega..." />
       </div>
 
-      <div class="entregas-grid">
+      <div class="entregas-grid" *ngIf="!cargandoEntregas">
         <div class="col">
           <h4 class="sec">Pendientes</h4>
           <ng-container *ngIf="hasPendientes; else noPend">

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
@@ -31,6 +31,12 @@ type Entrega = {
   fechaEntrega?: string;
   nota?: number;
   comentarios?: string;
+  rubricaNombre?: string;
+  rubricaUrl?: string;
+  rubricaTipo?: string;
+  informeNombre?: string;
+  informeUrl?: string;
+  informeTipo?: string;
   expanded?: boolean;
   ordenFecha?: number;
 };
@@ -66,6 +72,8 @@ export class DocenteTrabajoListComponent implements OnInit {
   entregaEnRevision: Entrega | null = null;
   notaInput: number | null = null;
   comentariosInput = '';
+  rubricaArchivo: File | null = null;
+  informeArchivo: File | null = null;
 
   constructor(
     private readonly temaService: TemaService,
@@ -255,6 +263,8 @@ export class DocenteTrabajoListComponent implements OnInit {
     this.entregaEnRevision = entrega;
     this.notaInput = null;
     this.comentariosInput = '';
+    this.rubricaArchivo = null;
+    this.informeArchivo = null;
     this.showEvalModal = true;
   }
 
@@ -263,12 +273,17 @@ export class DocenteTrabajoListComponent implements OnInit {
     this.entregaEnRevision = null;
     this.notaInput = null;
     this.comentariosInput = '';
+    this.rubricaArchivo = null;
+    this.informeArchivo = null;
   }
 
   guardarEvaluacion() {
     if (!this.entregaEnRevision || this.notaInput == null) {
       return;
     }
+
+    const rubricaAdjunta = this.adjuntoDesdeArchivo(this.rubricaArchivo);
+    const informeAdjunto = this.adjuntoDesdeArchivo(this.informeArchivo);
 
     const indice = this.entregas.findIndex((entrega) => entrega.id === this.entregaEnRevision!.id);
     if (indice >= 0) {
@@ -279,6 +294,12 @@ export class DocenteTrabajoListComponent implements OnInit {
         ordenFecha: Date.now(),
         nota: this.notaInput,
         comentarios: this.comentariosInput || 'Sin comentarios adicionales.',
+        rubricaNombre: rubricaAdjunta?.nombre,
+        rubricaUrl: rubricaAdjunta?.url,
+        rubricaTipo: rubricaAdjunta?.tipo,
+        informeNombre: informeAdjunto?.nombre,
+        informeUrl: informeAdjunto?.url,
+        informeTipo: informeAdjunto?.tipo,
       };
 
       if (this.grupoSeleccionado) {
@@ -348,6 +369,30 @@ export class DocenteTrabajoListComponent implements OnInit {
     });
 
     return mapa;
+  }
+
+  onRubricaSeleccionada(event: Event) {
+    const input = event.target as HTMLInputElement | null;
+    this.rubricaArchivo = input?.files?.[0] ?? null;
+  }
+
+  onInformeSeleccionado(event: Event) {
+    const input = event.target as HTMLInputElement | null;
+    this.informeArchivo = input?.files?.[0] ?? null;
+  }
+
+  private adjuntoDesdeArchivo(archivo: File | null):
+    | { nombre: string; url: string; tipo: string }
+    | null {
+    if (!archivo) {
+      return null;
+    }
+
+    return {
+      nombre: archivo.name,
+      url: URL.createObjectURL(archivo),
+      tipo: archivo.type || 'Archivo',
+    };
   }
 
   private mapEntrega(entrega: EvaluacionEntregaDto, evaluacion: EvaluacionGrupoDto): Entrega {


### PR DESCRIPTION
## Summary
- load evaluaciones del docente y mapear entregas por grupo para Trabajo de Título
- mostrar entregas pendientes y revisadas con filtros dinámicos y estados de carga/errores

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d777faf4832483b8a23445c31e14)