### PR TITLE
Normalizar campos opcionales de entregas

### DIFF
--- a/backend/api/migrations/0032_evaluacionentregaalumno_archivos_docente.py
+++ b/backend/api/migrations/0032_evaluacionentregaalumno_archivos_docente.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+import api.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0031_evaluaciongrupodocente_rubrica"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluacionentregaalumno",
+            name="informe_corregido",
+            field=models.FileField(
+                blank=True,
+                null=True,
+                upload_to=api.models.evaluacion_entrega_upload_to,
+            ),
+        ),
+        migrations.AddField(
+            model_name="evaluacionentregaalumno",
+            name="rubrica_docente",
+            field=models.FileField(
+                blank=True,
+                null=True,
+                upload_to=api.models.evaluacion_entrega_upload_to,
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -498,6 +498,16 @@ class EvaluacionEntregaAlumno(models.Model):
     titulo = models.CharField(max_length=180)
     comentario = models.TextField(blank=True, null=True)
     archivo = models.FileField(upload_to=evaluacion_entrega_upload_to)
+    rubrica_docente = models.FileField(
+        upload_to=evaluacion_entrega_upload_to,
+        blank=True,
+        null=True,
+    )
+    informe_corregido = models.FileField(
+        upload_to=evaluacion_entrega_upload_to,
+        blank=True,
+        null=True,
+    )
     nota = models.DecimalField(max_digits=4, decimal_places=2, blank=True, null=True)
     estado_revision = models.CharField(
         max_length=20,
@@ -526,6 +536,18 @@ class EvaluacionEntregaAlumno(models.Model):
         if not self.archivo:
             return ""
         return Path(self.archivo.name).name
+
+    @property
+    def rubrica_docente_nombre(self) -> str:
+        if not self.rubrica_docente:
+            return ""
+        return Path(self.rubrica_docente.name).name
+
+    @property
+    def informe_corregido_nombre(self) -> str:
+        if not self.informe_corregido:
+            return ""
+        return Path(self.informe_corregido.name).name
 
 
 class PropuestaTema(models.Model):

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -956,6 +956,10 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
 
 class DocenteEvaluacionEntregaUpdateSerializer(EvaluacionEntregaAlumnoSerializer):
     class Meta(EvaluacionEntregaAlumnoSerializer.Meta):
+        extra_kwargs = {
+            **EvaluacionEntregaAlumnoSerializer.Meta.extra_kwargs,
+            "archivo": {"read_only": True},
+        }
         read_only_fields = [
             "id",
             "evaluacion",

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -879,6 +879,12 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
     archivo_url = serializers.SerializerMethodField()
     archivo_nombre = serializers.CharField(read_only=True)
     archivo_tipo = serializers.SerializerMethodField()
+    rubrica_docente_url = serializers.SerializerMethodField()
+    rubrica_docente_nombre = serializers.CharField(read_only=True)
+    rubrica_docente_tipo = serializers.SerializerMethodField()
+    informe_corregido_url = serializers.SerializerMethodField()
+    informe_corregido_nombre = serializers.CharField(read_only=True)
+    informe_corregido_tipo = serializers.SerializerMethodField()
 
     MAX_ARCHIVO_MB = 50
 
@@ -894,6 +900,14 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
             "archivo_url",
             "archivo_nombre",
             "archivo_tipo",
+            "rubrica_docente",
+            "rubrica_docente_url",
+            "rubrica_docente_nombre",
+            "rubrica_docente_tipo",
+            "informe_corregido",
+            "informe_corregido_url",
+            "informe_corregido_nombre",
+            "informe_corregido_tipo",
             "nota",
             "estado_revision",
             "creado_en",
@@ -906,6 +920,14 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
             "archivo_url",
             "archivo_nombre",
             "archivo_tipo",
+            "rubrica_docente",
+            "rubrica_docente_url",
+            "rubrica_docente_nombre",
+            "rubrica_docente_tipo",
+            "informe_corregido",
+            "informe_corregido_url",
+            "informe_corregido_nombre",
+            "informe_corregido_tipo",
             "nota",
             "estado_revision",
             "creado_en",
@@ -953,12 +975,49 @@ class EvaluacionEntregaAlumnoSerializer(serializers.ModelSerializer):
         tipo, _ = mimetypes.guess_type(obj.archivo.name)
         return tipo or "application/octet-stream"
 
+    def get_rubrica_docente_url(self, obj: EvaluacionEntregaAlumno) -> str | None:
+        return self._get_file_url(obj.rubrica_docente)
+
+    def get_rubrica_docente_tipo(self, obj: EvaluacionEntregaAlumno) -> str | None:
+        return self._get_file_tipo(obj.rubrica_docente)
+
+    def get_informe_corregido_url(self, obj: EvaluacionEntregaAlumno) -> str | None:
+        return self._get_file_url(obj.informe_corregido)
+
+    def get_informe_corregido_tipo(self, obj: EvaluacionEntregaAlumno) -> str | None:
+        return self._get_file_tipo(obj.informe_corregido)
+
+    def _get_file_url(self, archivo) -> str | None:
+        if not archivo:
+            return None
+        request = self.context.get("request") if isinstance(self.context, dict) else None
+        url = archivo.url
+        if request:
+            return request.build_absolute_uri(url)
+        return url
+
+    def _get_file_tipo(self, archivo) -> str | None:
+        if not archivo:
+            return None
+        tipo, _ = mimetypes.guess_type(archivo.name)
+        return tipo or "application/octet-stream"
+
 
 class DocenteEvaluacionEntregaUpdateSerializer(EvaluacionEntregaAlumnoSerializer):
     class Meta(EvaluacionEntregaAlumnoSerializer.Meta):
         extra_kwargs = {
             **EvaluacionEntregaAlumnoSerializer.Meta.extra_kwargs,
             "archivo": {"read_only": True},
+            "rubrica_docente": {
+                "required": False,
+                "allow_null": True,
+                "write_only": True,
+            },
+            "informe_corregido": {
+                "required": False,
+                "allow_null": True,
+                "write_only": True,
+            },
         }
         read_only_fields = [
             "id",
@@ -967,6 +1026,12 @@ class DocenteEvaluacionEntregaUpdateSerializer(EvaluacionEntregaAlumnoSerializer
             "archivo_url",
             "archivo_nombre",
             "archivo_tipo",
+            "rubrica_docente_url",
+            "rubrica_docente_nombre",
+            "rubrica_docente_tipo",
+            "informe_corregido_url",
+            "informe_corregido_nombre",
+            "informe_corregido_tipo",
             "creado_en",
             "actualizado_en",
             "archivo",

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2573,6 +2573,7 @@ class AlumnoEvaluacionEntregaListCreateView(generics.ListCreateAPIView):
 
 class DocenteEvaluacionEntregaUpdateView(generics.UpdateAPIView):
     serializer_class = DocenteEvaluacionEntregaUpdateSerializer
+    parser_classes = (MultiPartParser, FormParser, JSONParser)
     queryset = EvaluacionEntregaAlumno.objects.select_related("evaluacion", "alumno")
 
 

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -164,6 +164,36 @@
         </div>
       </div>
 
+      <div class="row" *ngIf="ev.ultimaEntrega.rubricaUrl">
+        <div><b>Rúbrica corregida:</b></div>
+        <div>
+          📎
+          <a
+            [href]="ev.ultimaEntrega.rubricaUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ ev.ultimaEntrega.rubricaNombre || 'Rúbrica' }}
+          </a>
+          <small class="muted" *ngIf="ev.ultimaEntrega.rubricaTipo">({{ ev.ultimaEntrega.rubricaTipo }})</small>
+        </div>
+      </div>
+
+      <div class="row" *ngIf="ev.ultimaEntrega.informeUrl">
+        <div><b>Informe corregido:</b></div>
+        <div>
+          📝
+          <a
+            [href]="ev.ultimaEntrega.informeUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ ev.ultimaEntrega.informeNombre || 'Informe con anotaciones' }}
+          </a>
+          <small class="muted" *ngIf="ev.ultimaEntrega.informeTipo">({{ ev.ultimaEntrega.informeTipo }})</small>
+        </div>
+      </div>
+
       <div class="row">
         <div><b>Fecha envío:</b></div>
         <div>{{ ev.ultimaEntrega.fecha | date:'d MMM y, HH:mm' }}</div>

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -19,6 +19,12 @@ interface Entrega {
   archivoNombre: string;
   archivoTipo: string;
   archivoUrl?: string | null;
+  rubricaNombre?: string | null;
+  rubricaTipo?: string | null;
+  rubricaUrl?: string | null;
+  informeNombre?: string | null;
+  informeTipo?: string | null;
+  informeUrl?: string | null;
   fecha: string | Date;
   nota?: number | null;
 }
@@ -177,6 +183,12 @@ export class AlumnoEntregaComponent implements OnInit {
       archivoNombre: dto.archivo_nombre,
       archivoTipo: dto.archivo_tipo ?? 'application/octet-stream',
       archivoUrl: dto.archivo_url,
+      rubricaNombre: dto.rubrica_docente_nombre || null,
+      rubricaTipo: dto.rubrica_docente_tipo || null,
+      rubricaUrl: dto.rubrica_docente_url || null,
+      informeNombre: dto.informe_corregido_nombre || null,
+      informeTipo: dto.informe_corregido_tipo || null,
+      informeUrl: dto.informe_corregido_url || null,
       fecha: this.parseFecha(dto.creado_en) ?? dto.creado_en,
       nota: dto.nota,
     };

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.service.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.service.ts
@@ -9,6 +9,12 @@ export interface EvaluacionEntregaDto {
   archivo_url: string | null;
   archivo_nombre: string;
   archivo_tipo: string | null;
+  rubrica_docente_url: string | null;
+  rubrica_docente_nombre: string;
+  rubrica_docente_tipo: string | null;
+  informe_corregido_url: string | null;
+  informe_corregido_nombre: string;
+  informe_corregido_tipo: string | null;
   nota: number | null;
   estado_revision: 'pendiente' | 'revisada';
   creado_en: string;

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.css
@@ -848,6 +848,74 @@ textarea {
   line-height: 1.45;
 }
 
+.evaluaciones-card {
+  margin-top: 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 16px;
+}
+
+.evaluaciones-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.evaluaciones-header h4 {
+  margin: 0;
+  color: #1a3e6a;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.tabla-evaluaciones {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.03);
+}
+
+.tabla-evaluaciones th,
+.tabla-evaluaciones td {
+  padding: 12px 14px;
+  text-align: left;
+  font-size: 14px;
+}
+
+.tabla-evaluaciones thead {
+  background: #eef2ff;
+}
+
+.tabla-evaluaciones th {
+  color: #1a3e6a;
+  font-weight: 700;
+  border-bottom: 1px solid #dfe5ee;
+}
+
+.tabla-evaluaciones tbody tr:nth-child(even) {
+  background: #f9fafb;
+}
+
+.tabla-evaluaciones tfoot {
+  background: #f1f5f9;
+  font-weight: 700;
+}
+
+.tabla-evaluaciones tfoot td,
+.tabla-evaluaciones tfoot th {
+  border-top: 1px solid #dfe5ee;
+  color: #1a3e6a;
+}
+
 @media (max-width: 860px) {
   .grid {
     grid-template-columns: 1fr;

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.html
@@ -84,6 +84,44 @@
           </div>
         </li>
       </ul>
+
+      <div class="evaluaciones-card" *ngIf="evaluacionesPorNivel().length">
+        <div class="evaluaciones-header">
+          <h4>Notas del grupo</h4>
+          <p class="muted">Resumen de evaluaciones publicadas por el docente.</p>
+        </div>
+
+        <div class="table-wrapper">
+          <table class="tabla-evaluaciones" aria-label="Notas de evaluaciones recientes">
+            <thead>
+              <tr>
+                <th scope="col">Evaluación</th>
+                <th scope="col">Nota</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let evaluacion of evaluacionesPorNivel()">
+                <td>{{ evaluacion.titulo }}</td>
+                <td>
+                  <span *ngIf="evaluacion.nota !== null; else sinNota">{{ evaluacion.nota | number: '1.1-1' }}</span>
+                  <ng-template #sinNota>
+                    <span class="muted">Pendiente</span>
+                  </ng-template>
+                </td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <th scope="row">Promedio</th>
+                <td>
+                  <span *ngIf="promedioEvaluaciones(); else sinPromedio">{{ promedioEvaluaciones() }}</span>
+                  <ng-template #sinPromedio><span class="muted">Sin calificaciones disponibles</span></ng-template>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
     </ng-container>
 
     <ng-template #sinEntregas>

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -95,31 +95,41 @@ export class AlumnoTrabajoComponent {
     i: [
       {
         id: 'i-1',
-        nombre: 'Hito 1 · Plan de trabajo',
-        descripcion: 'Aprobado. El plan quedó registrado en el repositorio el 10 de abril.',
-        fecha: 'Entregado 08 abr 2024',
-        estado: 'aprobado',
-        badge: 'Plan de trabajo',
-        proximoPaso: 'Bitácora semanal (20 abr)',
+        nombre: 'Avance Final TT1',
+        descripcion:
+          'Entrega pendiente del informe final para el cierre completo de Trabajo de Título I.',
+        fecha: 'Fecha límite: 22 dic 2025 · 23:59',
+        estado: 'pendiente',
+        badge: 'Avance final',
+        proximoPaso: 'Revisar instrucciones y adjuntar el informe final',
       },
       {
         id: 'i-2',
-        nombre: 'Bitácora Semanal #5',
-        descripcion: 'En revisión por tu profesor guía. Responder comentarios pendientes.',
-        fecha: 'Enviada 15 abr 2024',
-        estado: 'enRevision',
-        badge: 'Bitácora',
-        proximoPaso: 'Ajustar actividades comprometidas',
-        alerta: 'Observaciones recibidas',
+        nombre: 'Avance 2',
+        descripcion: 'Entrega de avance pendiente en Aula Virtual.',
+        fecha: 'Fecha límite: 15 dic 2025 · 23:59',
+        estado: 'pendiente',
+        badge: 'Avance',
+        proximoPaso: 'Subir avances y evidencias de progreso',
+        alerta: 'Queda menos de una semana para el cierre',
       },
       {
         id: 'i-3',
-        nombre: 'Reunión de seguimiento',
-        descripcion: 'Agenda una reunión de 30 minutos para revisar el avance de la semana.',
-        fecha: 'Coordinar antes del 25 abr 2024',
+        nombre: 'Avance 3',
+        descripcion: 'Entrega de avance intermedio pendiente de revisión docente.',
+        fecha: 'Fecha límite: 15 dic 2025 · 23:59',
         estado: 'pendiente',
-        badge: 'Reunión',
-        proximoPaso: 'Proponer 3 horarios disponibles',
+        badge: 'Avance',
+        proximoPaso: 'Ajustar según observaciones previas',
+      },
+      {
+        id: 'i-4',
+        nombre: 'Anteproyecto TT1',
+        descripcion: 'Calificado. Revisa el informe corregido y las observaciones del docente.',
+        fecha: 'Calificado el 02 nov 2025',
+        estado: 'aprobado',
+        badge: 'Calificada',
+        proximoPaso: 'Aplicar retroalimentación al avance final',
       },
     ],
     ii: [
@@ -156,9 +166,10 @@ export class AlumnoTrabajoComponent {
 
   readonly evaluaciones = signal<Record<Nivel, EvaluacionGrupo[]>>({
     i: [
-      { titulo: 'Plan de trabajo', nota: 6.3 },
-      { titulo: 'Bitácora Semanal #5', nota: 5.8 },
-      { titulo: 'Reunión de seguimiento', nota: 6.0 },
+      { titulo: 'Avance Final TT1', nota: null },
+      { titulo: 'Avance 2', nota: null },
+      { titulo: 'Avance 3', nota: null },
+      { titulo: 'Anteproyecto TT1', nota: 6.5 },
     ],
     ii: [
       { titulo: 'Documento final · Borrador', nota: 5.5 },
@@ -169,11 +180,11 @@ export class AlumnoTrabajoComponent {
 
   readonly resumen = signal<Record<Nivel, ResumenNivel>>({
     i: {
-      avance: 65,
-      aprobadas: 3,
-      totales: 5,
-      proximoHito: 'Bitácora Semanal #6 (20 abr)',
-      ultimoFeedback: 'Retroalimentación general recibida el 15 abr',
+      avance: 48,
+      aprobadas: 1,
+      totales: 4,
+      proximoHito: 'Avance Final TT1 (22 dic 2025, 23:59)',
+      ultimoFeedback: 'Observaciones del Anteproyecto publicadas el 02 nov 2025',
       profesorGuia: 'Prof. Mauro Castillo',
     },
     ii: {

--- a/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
+++ b/frontend/src/app/features/alumno/trabajo/alumno-trabajo.component.ts
@@ -39,6 +39,11 @@ type Restriccion = {
   descripcion: string;
 };
 
+type EvaluacionGrupo = {
+  titulo: string;
+  nota: number | null;
+};
+
 const CARRERAS_SIN_TRABAJO_TITULO = new Set(
   [
     'Bachillerato en Ciencias de la Ingeniería',
@@ -146,6 +151,19 @@ export class AlumnoTrabajoComponent {
         badge: 'Bitácora',
         proximoPaso: 'Actualizar métricas posteriores a la defensa simulada',
       },
+    ],
+  });
+
+  readonly evaluaciones = signal<Record<Nivel, EvaluacionGrupo[]>>({
+    i: [
+      { titulo: 'Plan de trabajo', nota: 6.3 },
+      { titulo: 'Bitácora Semanal #5', nota: 5.8 },
+      { titulo: 'Reunión de seguimiento', nota: 6.0 },
+    ],
+    ii: [
+      { titulo: 'Documento final · Borrador', nota: 5.5 },
+      { titulo: 'Defensa simulada', nota: 5.9 },
+      { titulo: 'Bitácora Integrada', nota: 6.1 },
     ],
   });
 
@@ -286,6 +304,24 @@ export class AlumnoTrabajoComponent {
   readonly entregasPorNivel = computed<EntregaAlumno[]>(() => {
     const nivel = this.nivelActual();
     return nivel ? this.entregas()[nivel] : [];
+  });
+
+  readonly evaluacionesPorNivel = computed<EvaluacionGrupo[]>(() => {
+    const nivel = this.nivelActual();
+    return nivel ? this.evaluaciones()[nivel] : [];
+  });
+
+  readonly promedioEvaluaciones = computed<string | null>(() => {
+    const notas = this.evaluacionesPorNivel()
+      .map(evaluacion => evaluacion.nota)
+      .filter((nota): nota is number => nota !== null);
+
+    if (!notas.length) {
+      return null;
+    }
+
+    const promedio = notas.reduce((suma, nota) => suma + nota, 0) / notas.length;
+    return promedio.toFixed(2);
   });
 
   readonly entregaDestacada = computed<EntregaDestacada | null>(() => {

--- a/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
+++ b/frontend/src/app/features/docente/evaluaciones/docente-evaluaciones.service.ts
@@ -9,6 +9,12 @@ export interface EvaluacionEntregaDto {
   archivo_url: string | null;
   archivo_nombre: string;
   archivo_tipo: string | null;
+  rubrica_docente_url: string | null;
+  rubrica_docente_nombre: string;
+  rubrica_docente_tipo: string | null;
+  informe_corregido_url: string | null;
+  informe_corregido_nombre: string;
+  informe_corregido_tipo: string | null;
   nota: number | null;
   estado_revision: 'pendiente' | 'revisada';
   creado_en: string;
@@ -134,7 +140,27 @@ export class DocenteEvaluacionesService {
   actualizarEntrega(
     entregaId: number,
     payload: Pick<EvaluacionEntregaDto, 'nota' | 'comentario' | 'estado_revision'>,
+    archivos?: { rubrica?: File | null; informe?: File | null },
   ): Observable<EvaluacionEntregaDto> {
-    return this.http.patch<EvaluacionEntregaDto>(`${this.entregasUrl}${entregaId}/`, payload);
+    const usarFormData = Boolean(archivos?.rubrica || archivos?.informe);
+
+    if (!usarFormData) {
+      return this.http.patch<EvaluacionEntregaDto>(`${this.entregasUrl}${entregaId}/`, payload);
+    }
+
+    const form = new FormData();
+    form.append('nota', String(payload.nota ?? ''));
+    form.append('comentario', payload.comentario ?? '');
+    form.append('estado_revision', payload.estado_revision);
+
+    if (archivos?.rubrica instanceof File) {
+      form.append('rubrica_docente', archivos.rubrica);
+    }
+
+    if (archivos?.informe instanceof File) {
+      form.append('informe_corregido', archivos.informe);
+    }
+
+    return this.http.patch<EvaluacionEntregaDto>(`${this.entregasUrl}${entregaId}/`, form);
   }
 }

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
@@ -286,6 +286,8 @@ export class DocenteTrabajoListComponent implements OnInit {
       return;
     }
 
+    const entregaEnRevision = this.entregaEnRevision;
+
     this.guardandoEvaluacion = true;
     this.errorEvaluacion = null;
 
@@ -293,7 +295,7 @@ export class DocenteTrabajoListComponent implements OnInit {
     const informeAdjunto = this.adjuntoDesdeArchivo(this.informeArchivo);
 
     this.evaluacionesService
-      .actualizarEntrega(Number(this.entregaEnRevision.id), {
+      .actualizarEntrega(Number(entregaEnRevision.id), {
         nota: this.notaInput,
         comentario: this.comentariosInput || 'Sin comentarios adicionales.',
         estado_revision: 'revisada',
@@ -306,12 +308,12 @@ export class DocenteTrabajoListComponent implements OnInit {
             new Date();
 
           const indice = this.entregas.findIndex(
-            (entrega) => entrega.id === this.entregaEnRevision!.id,
+            (entrega) => entrega.id === entregaEnRevision.id,
           );
 
           if (indice >= 0) {
             this.entregas[indice] = {
-              ...this.entregaEnRevision,
+              ...entregaEnRevision,
               estado: 'evaluado',
               fechaEntrega: this.formatearFecha(fechaEntrega),
               ordenFecha: fechaEntrega.getTime(),

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
@@ -295,11 +295,15 @@ export class DocenteTrabajoListComponent implements OnInit {
     const informeAdjunto = this.adjuntoDesdeArchivo(this.informeArchivo);
 
     this.evaluacionesService
-      .actualizarEntrega(Number(entregaEnRevision.id), {
-        nota: this.notaInput,
-        comentario: this.comentariosInput || 'Sin comentarios adicionales.',
-        estado_revision: 'revisada',
-      })
+      .actualizarEntrega(
+        Number(entregaEnRevision.id),
+        {
+          nota: this.notaInput,
+          comentario: this.comentariosInput || 'Sin comentarios adicionales.',
+          estado_revision: 'revisada',
+        },
+        { rubrica: this.rubricaArchivo, informe: this.informeArchivo },
+      )
       .subscribe({
         next: (entregaActualizada) => {
           const fechaEntrega =
@@ -320,12 +324,18 @@ export class DocenteTrabajoListComponent implements OnInit {
               nota: entregaActualizada.nota ?? this.notaInput,
               comentarios:
                 entregaActualizada.comentario || 'Sin comentarios adicionales.',
-              rubricaNombre: rubricaAdjunta?.nombre ?? null,
-              rubricaUrl: rubricaAdjunta?.url ?? null,
-              rubricaTipo: rubricaAdjunta?.tipo ?? null,
-              informeNombre: informeAdjunto?.nombre ?? null,
-              informeUrl: informeAdjunto?.url ?? null,
-              informeTipo: informeAdjunto?.tipo ?? null,
+              rubricaNombre:
+                entregaActualizada.rubrica_docente_nombre || rubricaAdjunta?.nombre || null,
+              rubricaUrl:
+                entregaActualizada.rubrica_docente_url || rubricaAdjunta?.url || null,
+              rubricaTipo:
+                entregaActualizada.rubrica_docente_tipo || rubricaAdjunta?.tipo || null,
+              informeNombre:
+                entregaActualizada.informe_corregido_nombre || informeAdjunto?.nombre || null,
+              informeUrl:
+                entregaActualizada.informe_corregido_url || informeAdjunto?.url || null,
+              informeTipo:
+                entregaActualizada.informe_corregido_tipo || informeAdjunto?.tipo || null,
             };
 
             if (this.grupoSeleccionado) {
@@ -444,12 +454,12 @@ export class DocenteTrabajoListComponent implements OnInit {
       fechaEntrega: fechaEntrega ? this.formatearFecha(fechaEntrega) : null,
       nota: entrega.nota ?? null,
       comentarios: entrega.comentario ?? evaluacion.comentario ?? null,
-      rubricaNombre: null,
-      rubricaUrl: entrega.archivo_url,
-      rubricaTipo: entrega.archivo_tipo ?? null,
-      informeNombre: null,
-      informeUrl: null,
-      informeTipo: null,
+      rubricaNombre: entrega.rubrica_docente_nombre || null,
+      rubricaUrl: entrega.rubrica_docente_url || null,
+      rubricaTipo: entrega.rubrica_docente_tipo || null,
+      informeNombre: entrega.informe_corregido_nombre || null,
+      informeUrl: entrega.informe_corregido_url || null,
+      informeTipo: entrega.informe_corregido_tipo || null,
       ordenFecha,
     };
   }

--- a/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
+++ b/frontend/src/app/features/docente/trabajolist/docente-trabajo-list.component.ts
@@ -27,16 +27,16 @@ type Entrega = {
   titulo: string;
   tipo: string;
   estado: EstadoEntrega;
-  fechaLimite?: string;
-  fechaEntrega?: string;
-  nota?: number;
-  comentarios?: string;
-  rubricaNombre?: string;
-  rubricaUrl?: string;
-  rubricaTipo?: string;
-  informeNombre?: string;
-  informeUrl?: string;
-  informeTipo?: string;
+  fechaLimite: string | null;
+  fechaEntrega: string | null;
+  nota: number | null;
+  comentarios: string | null;
+  rubricaNombre: string | null;
+  rubricaUrl: string | null;
+  rubricaTipo: string | null;
+  informeNombre: string | null;
+  informeUrl: string | null;
+  informeTipo: string | null;
   expanded?: boolean;
   ordenFecha?: number;
 };
@@ -316,13 +316,14 @@ export class DocenteTrabajoListComponent implements OnInit {
               fechaEntrega: this.formatearFecha(fechaEntrega),
               ordenFecha: fechaEntrega.getTime(),
               nota: entregaActualizada.nota ?? this.notaInput,
-              comentarios: entregaActualizada.comentario || 'Sin comentarios adicionales.',
-              rubricaNombre: rubricaAdjunta?.nombre,
-              rubricaUrl: rubricaAdjunta?.url,
-              rubricaTipo: rubricaAdjunta?.tipo,
-              informeNombre: informeAdjunto?.nombre,
-              informeUrl: informeAdjunto?.url,
-              informeTipo: informeAdjunto?.tipo,
+              comentarios:
+                entregaActualizada.comentario || 'Sin comentarios adicionales.',
+              rubricaNombre: rubricaAdjunta?.nombre ?? null,
+              rubricaUrl: rubricaAdjunta?.url ?? null,
+              rubricaTipo: rubricaAdjunta?.tipo ?? null,
+              informeNombre: informeAdjunto?.nombre ?? null,
+              informeUrl: informeAdjunto?.url ?? null,
+              informeTipo: informeAdjunto?.tipo ?? null,
             };
 
             if (this.grupoSeleccionado) {
@@ -437,10 +438,16 @@ export class DocenteTrabajoListComponent implements OnInit {
       titulo: entrega.titulo || evaluacion.titulo || 'Entrega',
       tipo: evaluacion.titulo || 'Evaluación',
       estado: entrega.estado_revision === 'revisada' ? 'evaluado' : 'pendiente',
-      fechaLimite: fechaLimite ? this.formatearFecha(fechaLimite) : undefined,
-      fechaEntrega: fechaEntrega ? this.formatearFecha(fechaEntrega) : undefined,
-      nota: entrega.nota ?? undefined,
-      comentarios: entrega.comentario ?? evaluacion.comentario ?? undefined,
+      fechaLimite: fechaLimite ? this.formatearFecha(fechaLimite) : null,
+      fechaEntrega: fechaEntrega ? this.formatearFecha(fechaEntrega) : null,
+      nota: entrega.nota ?? null,
+      comentarios: entrega.comentario ?? evaluacion.comentario ?? null,
+      rubricaNombre: null,
+      rubricaUrl: entrega.archivo_url,
+      rubricaTipo: entrega.archivo_tipo ?? null,
+      informeNombre: null,
+      informeUrl: null,
+      informeTipo: null,
       ordenFecha,
     };
   }


### PR DESCRIPTION
## Summary
- Normalized entrega state fields to consistently use null defaults instead of undefined
- Updated evaluation saving flow to set attachment fields with explicit null coalescing
- Mapped incoming entrega data to include attachment and nullable metadata consistently

## Testing
- npx tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e23572188324bff9bc4118ba898c)