### PR TITLE
Fix bitacora upload destination info

### DIFF
--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
@@ -271,3 +271,4 @@ input[type="text"], textarea{
 .bitacora-card .sub{ font-size:12px; }
 .bitacora-card .meta{ gap:12px; }
 .eval-meta{ display:flex; gap:12px; flex-wrap:wrap; align-items:center; }
+.bitacora-sub{ margin-top:0; margin-bottom:8px; }

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
@@ -102,6 +102,23 @@ h2.ttl{
 .docente-detail a{ color:#1e66c9; font-weight:700; text-decoration:none; }
 .docente-detail a:hover{ text-decoration:underline; }
 
+.tag{
+  display:inline-block;
+  border-radius:999px;
+  padding:2px 8px;
+  background:#eef6ff;
+  border:1px solid #cfe3ff;
+  color:#1f2a37;
+  font-size:12px;
+  font-weight:800;
+  text-transform:none;
+}
+.tag.ghost{
+  background:#f5f8ff;
+  border-color:var(--border);
+  color:var(--muted);
+}
+
 /* Instrucciones dentro del detalle */
 .instrucciones.detail{
   background:#f7fbff;
@@ -247,3 +264,9 @@ input[type="text"], textarea{
 .bitacora-title{ display:flex; flex-direction:column; gap:2px; }
 .bitacora-actions{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-top:10px; }
 .btn.ghost{ background:transparent; border-color:var(--border); color:var(--primary); }
+.bitacoras-split .sec{ margin-bottom:8px; }
+.bitacora-card{ position:relative; overflow:hidden; }
+.bitacora-card.done{ background:#f7f9ff; }
+.bitacora-card .sub{ font-size:12px; }
+.bitacora-card .meta{ gap:12px; }
+.eval-meta{ display:flex; gap:12px; flex-wrap:wrap; align-items:center; }

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.css
@@ -84,6 +84,7 @@ h2.ttl{
   cursor:pointer;
   font-weight:700;
 }
+.eval-link{ cursor:pointer; }
 .info-row{ display:flex; gap:10px; align-items:center; margin:8px 0 12px; }
 .muted{ color:var(--muted); }
 

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -25,7 +25,7 @@
         <span *ngIf="b.entrega?.fecha">Entregada: {{ b.entrega?.fecha | date:'d MMM y, HH:mm' }}</span>
       </div>
       <div class="bitacora-actions">
-        <button class="btn primary" *ngIf="b.estado === 'pendiente'" (click)="openUploadBitacora(b); $event.stopPropagation();">Subir bitácora</button>
+        <button class="btn primary" *ngIf="b.estado === 'pendiente'" (click)="seleccionarBitacora(b); openUploadBitacora(b); $event.stopPropagation();">Subir bitácora</button>
         <a *ngIf="b.entrega?.archivoUrl" [href]="b.entrega?.archivoUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver entrega</a>
       </div>
     </article>
@@ -96,7 +96,128 @@
   </div>
 </section>
 
-<!-- Panel detalle -->
+<!-- Panel detalle bitácora -->
+<section class="card" *ngIf="seleccionBitacora() as b">
+  <div class="detail-head">
+    <h3>Detalle — {{ b.titulo }}</h3>
+    <button class="link" (click)="limpiarSeleccion()">✕ Cerrar</button>
+  </div>
+
+  <div class="instrucciones detail">
+    <div class="ins-head">
+      <b>Bitácora</b>
+      <span class="tag">Para: {{ b.evaluacionTitulo }}</span>
+    </div>
+    <p class="muted">{{ b.comentario || 'Revisar instrucciones en Aula Virtual.' }}</p>
+  </div>
+
+  <div class="info-row">
+    <span class="chip" [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
+    <span class="muted">Fecha límite: {{ b.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+  </div>
+
+  <div class="docente-detail">
+    <div class="docente-head">
+      <b>Detalles del docente</b>
+      <span class="muted">Información que acompaña a la bitácora</span>
+    </div>
+
+    <div class="row">
+      <div><b>Evaluación asociada:</b></div>
+      <div>{{ b.evaluacionTitulo }}</div>
+    </div>
+
+    <div class="row">
+      <div><b>Comentario:</b></div>
+      <div>{{ b.comentario || 'Sin comentarios adicionales.' }}</div>
+    </div>
+  </div>
+
+  <div *ngIf="b.estado === 'pendiente'; else bitacoraEntrega">
+    <p class="muted">Esta bitácora está pendiente. Debes subir tu archivo para completar la entrega.</p>
+    <button class="btn primary" (click)="openUploadBitacora(b)">Subir archivo</button>
+  </div>
+
+  <ng-template #bitacoraEntrega>
+    <div *ngIf="b.entrega; else sinEntregaBitacora" class="entrega">
+      <div class="row">
+        <div><b>Título:</b></div>
+        <div>{{ b.entrega?.titulo }}</div>
+      </div>
+
+      <div class="row" *ngIf="b.entrega?.comentario">
+        <div><b>Comentario:</b></div>
+        <div>{{ b.entrega?.comentario }}</div>
+      </div>
+
+      <div class="row">
+        <div><b>Archivo:</b></div>
+        <div>
+          📄
+          <ng-container *ngIf="b.entrega?.archivoUrl; else archivoSinLinkBitacora">
+            <a
+              [href]="b.entrega?.archivoUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ b.entrega?.archivoNombre }}
+            </a>
+          </ng-container>
+          <ng-template #archivoSinLinkBitacora>
+            {{ b.entrega?.archivoNombre }}
+          </ng-template>
+          <small class="muted">({{ b.entrega?.archivoTipo }})</small>
+        </div>
+      </div>
+
+      <div class="row" *ngIf="b.entrega?.rubricaUrl">
+        <div><b>Rúbrica corregida:</b></div>
+        <div>
+          📎
+          <a
+            [href]="b.entrega?.rubricaUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ b.entrega?.rubricaNombre || 'Rúbrica' }}
+          </a>
+          <small class="muted" *ngIf="b.entrega?.rubricaTipo">({{ b.entrega?.rubricaTipo }})</small>
+        </div>
+      </div>
+
+      <div class="row" *ngIf="b.entrega?.informeUrl">
+        <div><b>Informe corregido:</b></div>
+        <div>
+          📝
+          <a
+            [href]="b.entrega?.informeUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ b.entrega?.informeNombre || 'Informe con anotaciones' }}
+          </a>
+          <small class="muted" *ngIf="b.entrega?.informeTipo">({{ b.entrega?.informeTipo }})</small>
+        </div>
+      </div>
+
+      <div class="row">
+        <div><b>Fecha envío:</b></div>
+        <div>{{ b.entrega?.fecha | date:'d MMM y, HH:mm' }}</div>
+      </div>
+
+      <div class="row" *ngIf="b.entrega?.nota != null">
+        <div><b>Nota:</b></div>
+        <div><span class="nota">{{ b.entrega?.nota }}</span></div>
+      </div>
+    </div>
+
+    <ng-template #sinEntregaBitacora>
+      <p class="muted">Aún no existe registro de entrega.</p>
+    </ng-template>
+  </ng-template>
+</section>
+
+<!-- Panel detalle evaluación -->
 <section class="card" *ngIf="seleccionada() as ev">
   <div class="detail-head">
     <h3>Detalle — {{ ev.titulo }}</h3>

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -251,6 +251,8 @@
       <button class="x" (click)="closeUpload()">✕</button>
     </header>
 
+    <p class="muted" *ngIf="destinoLabel()">Para: {{ destinoLabel() }}</p>
+
     <form class="form" (ngSubmit)="submitUpload()">
       <label class="field">
         <span class="lbl">Título del envío</span>

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -16,13 +16,11 @@
       <div class="grid bitacoras-grid" *ngIf="bitacorasPendientes().length; else noBitPend">
         <article class="item clickable bitacora-card" *ngFor="let b of bitacorasPendientes()" (click)="onBitacoraClick(b)">
           <div class="top">
-            <div class="bitacora-title">
-              <b class="title">Bitácora {{ b.indice + 1 }} de evaluación {{ b.evaluacionTitulo }}</b>
-              <span class="sub muted">Bitácora: {{ b.titulo }}</span>
-            </div>
+            <b class="title">Bitácora {{ b.indice + 1 }} de evaluación {{ b.evaluacionTitulo }}</b>
             <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
           </div>
-          <p class="desc">Sigue el progreso semanal de tu trabajo.</p>
+          <p class="desc" *ngIf="b.titulo">{{ b.titulo }}</p>
+          <p class="desc muted">Sigue el progreso semanal de tu trabajo.</p>
           <div class="meta">
             <span>Fecha límite: {{ b.fechaLimite | date:'d MMM y, HH:mm' }}</span>
           </div>
@@ -42,16 +40,14 @@
       <div class="grid bitacoras-grid" *ngIf="bitacorasCompletadas().length; else noBitComp">
         <article class="item clickable bitacora-card done" *ngFor="let b of bitacorasCompletadas()" (click)="onBitacoraClick(b)">
           <div class="top">
-            <div class="bitacora-title">
-              <b class="title">Bitácora {{ b.indice + 1 }} de evaluación {{ b.evaluacionTitulo }}</b>
-              <span class="sub muted">Bitácora: {{ b.titulo }}</span>
-            </div>
+            <b class="title">Bitácora {{ b.indice + 1 }} de evaluación {{ b.evaluacionTitulo }}</b>
             <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
           </div>
-          <p class="desc">Revisa los envíos y correcciones disponibles para esta bitácora.</p>
+          <p class="desc" *ngIf="b.titulo">{{ b.titulo }}</p>
+          <p class="desc muted">Revisa los envíos y correcciones disponibles para esta bitácora.</p>
           <div class="meta">
             <span *ngIf="b.entrega?.fecha">Entregada: {{ b.entrega?.fecha | date:'d MMM y, HH:mm' }}</span>
-            <span *ngIf="b.entrega?.nota != null">Nota: <b>{{ b.entrega?.nota }}</b></span>
+            <span *ngIf="b.entrega?.nota != null">• Nota: <b>{{ b.entrega?.nota }}</b></span>
           </div>
           <div class="bitacora-actions">
             <a *ngIf="b.entrega?.archivoUrl" [href]="b.entrega?.archivoUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver entrega</a>

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -17,9 +17,8 @@
         <article class="item clickable bitacora-card" *ngFor="let b of bitacorasPendientes()" (click)="onBitacoraClick(b)">
           <div class="top">
             <div class="bitacora-title">
-              <small class="tag ghost">Evaluación</small>
-              <b class="title">{{ b.evaluacionTitulo }}</b>
-              <span class="sub muted">Bitácora {{ b.indice + 1 }} • {{ b.titulo }}</span>
+              <b class="title">Bitácora {{ b.indice + 1 }} de evaluación {{ b.evaluacionTitulo }}</b>
+              <span class="sub muted">Bitácora: {{ b.titulo }}</span>
             </div>
             <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
           </div>
@@ -29,7 +28,7 @@
           </div>
           <div class="bitacora-actions">
             <button class="btn primary" (click)="openUploadBitacora(b); $event.stopPropagation();">Subir bitácora</button>
-            <button class="btn ghost" (click)="openEvaluacion(b.evaluacionId); $event.stopPropagation();">Ver evaluación</button>
+            <button class="btn ghost" (click)="openEvaluacion(b.evaluacionId); $event.stopPropagation();">Detalles</button>
           </div>
         </article>
       </div>
@@ -44,9 +43,8 @@
         <article class="item clickable bitacora-card done" *ngFor="let b of bitacorasCompletadas()" (click)="onBitacoraClick(b)">
           <div class="top">
             <div class="bitacora-title">
-              <small class="tag ghost">Evaluación</small>
-              <b class="title">{{ b.evaluacionTitulo }}</b>
-              <span class="sub muted">Bitácora {{ b.indice + 1 }} • {{ b.titulo }}</span>
+              <b class="title">Bitácora {{ b.indice + 1 }} de evaluación {{ b.evaluacionTitulo }}</b>
+              <span class="sub muted">Bitácora: {{ b.titulo }}</span>
             </div>
             <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
           </div>
@@ -58,7 +56,7 @@
           <div class="bitacora-actions">
             <a *ngIf="b.entrega?.archivoUrl" [href]="b.entrega?.archivoUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver entrega</a>
             <a *ngIf="b.entrega?.informeUrl" [href]="b.entrega?.informeUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver correcciones</a>
-            <button class="btn ghost" (click)="openEvaluacion(b.evaluacionId); $event.stopPropagation();">Ver evaluación</button>
+            <button class="btn ghost" (click)="openEvaluacion(b.evaluacionId); $event.stopPropagation();">Detalles</button>
           </div>
         </article>
       </div>
@@ -136,14 +134,15 @@
 <!-- Panel detalle bitácora -->
 <section class="card" *ngIf="seleccionBitacora() as b">
   <div class="detail-head">
-    <h3>Detalle — {{ b.titulo }}</h3>
+    <h3>Detalle — Bitácora {{ b.indice + 1 }} de evaluación {{ b.evaluacionTitulo }}</h3>
     <button class="link" (click)="limpiarSeleccion()">✕ Cerrar</button>
   </div>
+
+  <p class="muted bitacora-sub">Bitácora: {{ b.titulo }}</p>
 
   <div class="instrucciones detail">
     <div class="ins-head">
       <b>Bitácora</b>
-      <span class="tag">Para: {{ b.evaluacionTitulo }}</span>
     </div>
     <p class="muted">Revisa las indicaciones de tu docente en la evaluación asociada antes de subir tu bitácora.</p>
   </div>
@@ -175,7 +174,8 @@
     <div class="row">
       <div><b>Evaluación asociada:</b></div>
       <div class="eval-link" (click)="openEvaluacion(b.evaluacionId)">
-        <span class="link">{{ b.evaluacionTitulo }}</span>
+        <span class="link">Detalles</span>
+        <span class="muted">{{ b.evaluacionTitulo }}</span>
       </div>
     </div>
   </div>

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -23,12 +23,13 @@
             </div>
             <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
           </div>
-          <p class="desc">{{ b.comentario || 'Sigue el progreso semanal de tu trabajo.' }}</p>
+          <p class="desc">Sigue el progreso semanal de tu trabajo.</p>
           <div class="meta">
             <span>Fecha límite: {{ b.fechaLimite | date:'d MMM y, HH:mm' }}</span>
           </div>
           <div class="bitacora-actions">
             <button class="btn primary" (click)="openUploadBitacora(b); $event.stopPropagation();">Subir bitácora</button>
+            <button class="btn ghost" (click)="openEvaluacion(b.evaluacionId); $event.stopPropagation();">Ver evaluación</button>
           </div>
         </article>
       </div>
@@ -49,7 +50,7 @@
             </div>
             <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
           </div>
-          <p class="desc">{{ b.comentario || 'Revisa los comentarios del docente sobre tu avance.' }}</p>
+          <p class="desc">Revisa los envíos y correcciones disponibles para esta bitácora.</p>
           <div class="meta">
             <span *ngIf="b.entrega?.fecha">Entregada: {{ b.entrega?.fecha | date:'d MMM y, HH:mm' }}</span>
             <span *ngIf="b.entrega?.nota != null">Nota: <b>{{ b.entrega?.nota }}</b></span>
@@ -57,6 +58,7 @@
           <div class="bitacora-actions">
             <a *ngIf="b.entrega?.archivoUrl" [href]="b.entrega?.archivoUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver entrega</a>
             <a *ngIf="b.entrega?.informeUrl" [href]="b.entrega?.informeUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver correcciones</a>
+            <button class="btn ghost" (click)="openEvaluacion(b.evaluacionId); $event.stopPropagation();">Ver evaluación</button>
           </div>
         </article>
       </div>
@@ -143,7 +145,7 @@
       <b>Bitácora</b>
       <span class="tag">Para: {{ b.evaluacionTitulo }}</span>
     </div>
-    <p class="muted">{{ b.comentario || 'Revisar instrucciones en Aula Virtual.' }}</p>
+    <p class="muted">Revisa las indicaciones de tu docente en la evaluación asociada antes de subir tu bitácora.</p>
   </div>
 
   <div class="info-row">
@@ -172,12 +174,9 @@
 
     <div class="row">
       <div><b>Evaluación asociada:</b></div>
-      <div>{{ b.evaluacionTitulo }}</div>
-    </div>
-
-    <div class="row">
-      <div><b>Comentario:</b></div>
-      <div>{{ b.comentario || 'Sin comentarios adicionales.' }}</div>
+      <div class="eval-link" (click)="openEvaluacion(b.evaluacionId)">
+        <span class="link">{{ b.evaluacionTitulo }}</span>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.html
@@ -7,28 +7,63 @@
       <h3>Bitácoras</h3>
       <p class="muted">Seguimiento semanal solicitado por tu docente.</p>
     </div>
-    <span class="chip warn">{{ bitacoras().filter(b => b.estado === 'pendiente').length }} pendientes</span>
+    <span class="chip warn">{{ bitacorasPendientes().length }} pendientes</span>
   </div>
 
-  <div class="grid bitacoras-grid">
-    <article class="item clickable" *ngFor="let b of bitacoras()" (click)="onBitacoraClick(b)">
-      <div class="top">
-        <div class="bitacora-title">
-          <b class="title">{{ b.titulo }}</b>
-          <small class="muted">Evaluación: {{ b.evaluacionTitulo }}</small>
-        </div>
-        <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
+  <div class="split bitacoras-split">
+    <div>
+      <h4 class="sec">Pendientes</h4>
+      <div class="grid bitacoras-grid" *ngIf="bitacorasPendientes().length; else noBitPend">
+        <article class="item clickable bitacora-card" *ngFor="let b of bitacorasPendientes()" (click)="onBitacoraClick(b)">
+          <div class="top">
+            <div class="bitacora-title">
+              <small class="tag ghost">Evaluación</small>
+              <b class="title">{{ b.evaluacionTitulo }}</b>
+              <span class="sub muted">Bitácora {{ b.indice + 1 }} • {{ b.titulo }}</span>
+            </div>
+            <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
+          </div>
+          <p class="desc">{{ b.comentario || 'Sigue el progreso semanal de tu trabajo.' }}</p>
+          <div class="meta">
+            <span>Fecha límite: {{ b.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+          </div>
+          <div class="bitacora-actions">
+            <button class="btn primary" (click)="openUploadBitacora(b); $event.stopPropagation();">Subir bitácora</button>
+          </div>
+        </article>
       </div>
-      <p class="desc">{{ b.comentario || 'Sigue el progreso semanal de tu trabajo.' }}</p>
-      <div class="meta">
-        <span>Fecha límite: {{ b.fechaLimite | date:'d MMM y, HH:mm' }}</span>
-        <span *ngIf="b.entrega?.fecha">Entregada: {{ b.entrega?.fecha | date:'d MMM y, HH:mm' }}</span>
+      <ng-template #noBitPend>
+        <p class="muted">No tienes bitácoras pendientes.</p>
+      </ng-template>
+    </div>
+
+    <div>
+      <h4 class="sec">Completadas</h4>
+      <div class="grid bitacoras-grid" *ngIf="bitacorasCompletadas().length; else noBitComp">
+        <article class="item clickable bitacora-card done" *ngFor="let b of bitacorasCompletadas()" (click)="onBitacoraClick(b)">
+          <div class="top">
+            <div class="bitacora-title">
+              <small class="tag ghost">Evaluación</small>
+              <b class="title">{{ b.evaluacionTitulo }}</b>
+              <span class="sub muted">Bitácora {{ b.indice + 1 }} • {{ b.titulo }}</span>
+            </div>
+            <span [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
+          </div>
+          <p class="desc">{{ b.comentario || 'Revisa los comentarios del docente sobre tu avance.' }}</p>
+          <div class="meta">
+            <span *ngIf="b.entrega?.fecha">Entregada: {{ b.entrega?.fecha | date:'d MMM y, HH:mm' }}</span>
+            <span *ngIf="b.entrega?.nota != null">Nota: <b>{{ b.entrega?.nota }}</b></span>
+          </div>
+          <div class="bitacora-actions">
+            <a *ngIf="b.entrega?.archivoUrl" [href]="b.entrega?.archivoUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver entrega</a>
+            <a *ngIf="b.entrega?.informeUrl" [href]="b.entrega?.informeUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver correcciones</a>
+          </div>
+        </article>
       </div>
-      <div class="bitacora-actions">
-        <button class="btn primary" *ngIf="b.estado === 'pendiente'" (click)="seleccionarBitacora(b); openUploadBitacora(b); $event.stopPropagation();">Subir bitácora</button>
-        <a *ngIf="b.entrega?.archivoUrl" [href]="b.entrega?.archivoUrl" target="_blank" rel="noopener noreferrer" class="btn ghost" (click)="$event.stopPropagation()">Ver entrega</a>
-      </div>
-    </article>
+      <ng-template #noBitComp>
+        <p class="muted">Aún no tienes bitácoras entregadas.</p>
+      </ng-template>
+    </div>
   </div>
 </section>
 
@@ -114,6 +149,19 @@
   <div class="info-row">
     <span class="chip" [ngClass]="estadoClase(b.estado)">{{ b.estado }}</span>
     <span class="muted">Fecha límite: {{ b.fechaLimite | date:'d MMM y, HH:mm' }}</span>
+  </div>
+
+  <div class="instrucciones detail" *ngIf="evaluacionAsociada(b) as evRef">
+    <div class="ins-head">
+      <b>Detalles de la evaluación</b>
+      <span class="tag">{{ evRef.tipo | titlecase }}</span>
+    </div>
+    <p class="muted">{{ evRef.descripcion || 'Revisa las indicaciones originales de la evaluación antes de subir tu bitácora.' }}</p>
+    <div class="meta eval-meta">
+      <span [ngClass]="estadoClase(evRef.estado)" class="chip">{{ evRef.estado }}</span>
+      <ng-container *ngIf="evRef.fechaLimite">Fecha límite: {{ evRef.fechaLimite | date:'d MMM y, HH:mm' }}</ng-container>
+      <ng-container *ngIf="evRef.ultimaEntrega?.nota != null">Nota última entrega: <b>{{ evRef.ultimaEntrega?.nota }}</b></ng-container>
+    </div>
   </div>
 
   <div class="docente-detail">

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -109,6 +109,8 @@ export class AlumnoEntregaComponent implements OnInit {
   pendientes = () => this._evaluaciones().filter(e => e.estado === 'pendiente');
   completadas = () => this._evaluaciones().filter(e => e.estado !== 'pendiente');
   bitacoras = () => this._bitacoras();
+  bitacorasPendientes = () => this._bitacoras().filter(b => b.estado === 'pendiente');
+  bitacorasCompletadas = () => this._bitacoras().filter(b => b.estado !== 'pendiente');
   destinoSubida = () => this._destinoSubida();
 
   seleccionada = () => this._seleccion();
@@ -303,6 +305,7 @@ export class AlumnoEntregaComponent implements OnInit {
 
   onBitacoraClick(bitacora: BitacoraProgramada) {
     this.seleccionarBitacora(bitacora);
+    this._destinoSubida.set(null);
   }
 
   private actualizarBitacoraEntregada(
@@ -570,5 +573,10 @@ export class AlumnoEntregaComponent implements OnInit {
           this._errorMsg.set('No pudimos subir tu entrega. Intenta nuevamente.');
         },
       });
+  }
+
+  evaluacionAsociada(bitacora: BitacoraProgramada | null): Evaluacion | null {
+    if (!bitacora) return null;
+    return this._evaluaciones().find(ev => ev.id === bitacora.evaluacionId) ?? null;
   }
 }

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -356,6 +356,12 @@ export class AlumnoEntregaComponent implements OnInit {
     this._seleccion.set(null);
   }
 
+  openEvaluacion(evaluacionId: number) {
+    const encontrada = this._evaluaciones().find(ev => ev.id === evaluacionId) || null;
+    this._seleccion.set(encontrada);
+    this._seleccionBitacora.set(null);
+  }
+
   limpiarSeleccion() {
     this._seleccion.set(null);
     this._seleccionBitacora.set(null);
@@ -425,7 +431,7 @@ export class AlumnoEntregaComponent implements OnInit {
     if (bitacora.estado !== 'pendiente') return;
     this.seleccionarBitacora(bitacora);
     this._destinoSubida.set({ tipo: 'bitacora', evaluacionId: bitacora.evaluacionId, bitacora });
-    this.prepararFormulario(bitacora.titulo, bitacora.comentario || '');
+    this.prepararFormulario(bitacora.titulo, '');
   }
 
   private prepararFormulario(tituloPorDefecto = '', comentarioPorDefecto = '') {

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -186,7 +186,7 @@ export class AlumnoEntregaComponent implements OnInit {
           titulo: bitacora.titulo,
           comentario: bitacora.comentario,
           fechaLimite: this.parseFecha(bitacora.fecha) ?? bitacora.fecha,
-          estado: (bitacora.estado as EstadoBitacora) || 'pendiente',
+          estado: this.mapEstadoBitacora(bitacora.estado),
           entrega: bitacora.entrega ? this.mapEntregaDto(bitacora.entrega) : null,
         }))
       )
@@ -214,6 +214,17 @@ export class AlumnoEntregaComponent implements OnInit {
     }
     if (normalizado === 'en progreso') {
       return 'pendiente';
+    }
+    return 'pendiente';
+  }
+
+  private mapEstadoBitacora(estado: string | null | undefined): EstadoBitacora {
+    const normalizado = (estado ?? '').trim().toLowerCase();
+    if (normalizado === 'entregada') {
+      return 'entregada';
+    }
+    if (normalizado === 'calificada' || normalizado === 'evaluada') {
+      return 'calificada';
     }
     return 'pendiente';
   }
@@ -298,7 +309,7 @@ export class AlumnoEntregaComponent implements OnInit {
     entrega: Entrega,
   ) {
     const indice = destino.bitacora?.indice ?? entrega.bitacoraIndice ?? null;
-    if (!indice) return;
+    if (indice == null) return;
 
     this._bitacoras.set(
       this._bitacoras().map(b => {

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.component.ts
@@ -108,6 +108,7 @@ export class AlumnoEntregaComponent implements OnInit {
   pendientes = () => this._evaluaciones().filter(e => e.estado === 'pendiente');
   completadas = () => this._evaluaciones().filter(e => e.estado !== 'pendiente');
   bitacoras = () => this._bitacoras();
+  destinoSubida = () => this._destinoSubida();
 
   seleccionada = () => this._seleccion();
 
@@ -336,6 +337,23 @@ export class AlumnoEntregaComponent implements OnInit {
       case 'calificada': return 'chip ok';
       default: return 'chip';
     }
+  }
+
+  destinoLabel(): string {
+    const destino = this._destinoSubida();
+    if (!destino) return '';
+
+    if (destino.tipo === 'bitacora') {
+      const evaluacionTitulo =
+        this._evaluaciones().find(ev => ev.id === destino.evaluacionId)?.titulo ||
+        destino.bitacora?.evaluacionTitulo ||
+        'Evaluación';
+      const bitacoraTitulo = destino.bitacora?.titulo || 'Bitácora';
+      return `Bitácora: ${bitacoraTitulo} — ${evaluacionTitulo}`;
+    }
+
+    const evaluacionTitulo = this._evaluaciones().find(ev => ev.id === destino.evaluacionId)?.titulo;
+    return `Evaluación: ${evaluacionTitulo || 'Sin título'}`;
   }
 
   getInstrucciones(ev: Evaluacion): string[] {

--- a/frontend/src/app/features/alumno/entrega/alumno-entrega.service.ts
+++ b/frontend/src/app/features/alumno/entrega/alumno-entrega.service.ts
@@ -83,7 +83,7 @@ export class AlumnoEntregasService {
     }
     formData.append('archivo', payload.archivo);
     formData.append('alumno', String(alumnoId));
-    if (payload.bitacoraIndice) {
+    if (payload.bitacoraIndice !== undefined && payload.bitacoraIndice !== null) {
       formData.append('bitacora_indice', String(payload.bitacoraIndice));
     }
 


### PR DESCRIPTION
## Summary
- show upload modal text identifying the evaluation or bitácora selected for upload
- send bitácora index values even when zero or falsy so uploads reach the backend

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927677207e48324b149c8f4836287b6)